### PR TITLE
Undo 23b988cd5ffe2c89553f311fa66738a69202f2ef but keep naming

### DIFF
--- a/jsonrpc/provider/src/provider.ts
+++ b/jsonrpc/provider/src/provider.ts
@@ -19,7 +19,9 @@ export class JsonRpcProvider extends IJsonRpcProvider {
   constructor(connection: IJsonRpcConnection) {
     super(connection);
     this.connection = this.setConnection(connection);
-    this.registerEventListeners();
+    if (this.connection.connected) {
+      this.registerEventListeners();
+    }
   }
 
   public async connect(connection: string | IJsonRpcConnection = this.connection): Promise<void> {
@@ -107,6 +109,7 @@ export class JsonRpcProvider extends IJsonRpcProvider {
     }
     this.connection = this.setConnection(connection);
     await this.connection.open();
+    this.registerEventListeners();
     this.events.emit("connect");
   }
 


### PR DESCRIPTION
23b988cd5ffe2c89553f311fa66738a69202f2ef actually introduced the bug reported in https://github.com/WalletConnect/walletconnect-monorepo/issues/839 .

What I believe is happening is that 23b988cd5ffe2c89553f311fa66738a69202f2ef causes us to evade an existing error flow.   `@walletconnect/jsonrpc-provider` now re-emits the QR code closed error in https://github.com/WalletConnect/walletconnect-monorepo/blob/v1.0/packages%2Fhelpers%2Fsigner-connection%2Fsrc%2Findex.ts#L201 and `@walletconnect/ethereum-provider` does not have a listener specified for `error` so we are blowing up within `EventEmitter`.

Prior to 23b988cd5ffe2c89553f311fa66738a69202f2ef, the QR code being aborted would resolve as a rejection in https://github.com/WalletConnect/walletconnect-monorepo/blob/v1.0/packages%2Fhelpers%2Fsigner-connection%2Fsrc%2Findex.ts#L70 and we would just blow up in https://github.com/WalletConnect/walletconnect-utils/blob/44ea55faf3159cc73078a306ad029705a42b6285/jsonrpc/provider/src/provider.ts#L111

This error flow is what web3-react is explicitly handling in https://github.com/NoahZinsmeister/web3-react/blob/main/packages%2Fwalletconnect%2Fsrc%2Findex.ts#L162 and since we are now blowing up within `EventEmitter` instead, they are blowing up.

The fix is to undo 23b988cd5ffe2c89553f311fa66738a69202f2ef , but keep the naming. We no longer add the `error` listener prior to the QR code connection and respect the existing error flow.
