### PR TITLE
fix(jsonrpc-utils): handle non-object payloads in `isJsonRpcPayload`

### DIFF
--- a/jsonrpc/utils/src/validators.ts
+++ b/jsonrpc/utils/src/validators.ts
@@ -9,7 +9,12 @@ import {
 } from "./types";
 
 export function isJsonRpcPayload(payload: any): payload is JsonRpcPayload {
-  return "id" in payload && "jsonrpc" in payload && payload.jsonrpc === "2.0";
+  return (
+    typeof payload === "object" &&
+    "id" in payload &&
+    "jsonrpc" in payload &&
+    payload.jsonrpc === "2.0"
+  );
 }
 
 export function isJsonRpcRequest<T = any>(payload: JsonRpcPayload): payload is JsonRpcRequest<T> {

--- a/jsonrpc/utils/test/validators.test.ts
+++ b/jsonrpc/utils/test/validators.test.ts
@@ -15,6 +15,8 @@ describe("Validators", () => {
     chai.expect(isJsonRpcPayload(TEST_JSONRPC_REQUEST)).to.be.true;
     chai.expect(isJsonRpcPayload(TEST_JSONRPC_RESULT)).to.be.true;
     chai.expect(isJsonRpcPayload(TEST_JSONRPC_ERROR)).to.be.true;
+    chai.expect(isJsonRpcPayload("")).to.be.false;
+    chai.expect(isJsonRpcPayload(1)).to.be.false;
   });
 
   it("isJsonRpcRequest", () => {


### PR DESCRIPTION
Fixes:

- https://github.com/WalletConnect/walletconnect-monorepo/issues/1106
- https://github.com/WalletConnect/walletconnect-monorepo/issues/558

## Context

When calling `isJsonRpcRequest` inside the `RELAYER_EVENTS.message` handler [here](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/sign-client/src/controllers/engine.ts#L442), `payload` seems to occasionally decode to a non-object value such as  empty string `""` or `1` (why is another question I wasn't yet able to answer).

`isJsonRpcRequest` relies on `isJsonRpcPayload`, which allows `payload` as `any`, but assumes it can be operated on like an object.

This leads to invalid operations such as `"id" in ""`, resulting in the observed TypeError.

The bug could be reproduced by running the new test cases without the fix:

<img width="542" alt="Screenshot 2022-05-31 at 17 09 43" src="https://user-images.githubusercontent.com/8663099/171209888-67941846-efa3-488f-84be-14ed2bb1736b.png">


## Solution

- Narrow the type of `payload` via `typeof` before performing object-specific operations on it
- Add a regression test validating against invalid `payload` inputs.

### Validation

- I've validated the fix against the react-app@2.0.0-beta.100 by symlinking in the modified `jsonrpc-utils` build.