### PR TITLE
Error validation in parseConnectionError

### DIFF
--- a/jsonrpc/utils/src/error.ts
+++ b/jsonrpc/utils/src/error.ts
@@ -63,7 +63,7 @@ export function validateJsonRpcError(response: JsonRpcError): JsonRpcValidation 
 }
 
 export function parseConnectionError(e: Error, url: string, type: string): Error {
-  return e.message.includes("getaddrinfo ENOTFOUND") || e.message.includes("connect ECONNREFUSED")
+  return e && (e.message.includes("getaddrinfo ENOTFOUND") || e.message.includes("connect ECONNREFUSED"))
     ? new Error(`Unavailable ${type} RPC url at ${url}`)
     : e;
 }


### PR DESCRIPTION
When connection is lost `parseConnectionError` is throwing an error: 
```
 Uncaught TypeError: Cannot read property 'message' of undefined
```

Adding this validation will allow to automatically reconnect websockets.

see: 
https://github.com/WalletConnect/walletconnect-utils/issues/8