### PR TITLE
fix: parsing error on ws error event

### DIFF
--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -105,7 +105,8 @@ export class WsConnection implements IJsonRpcConnection {
         resolve(socket);
       };
       socket.onerror = (event: Event) => {
-        const error = this.parseError((event as ErrorEvent).error);
+        const errorEvent = event as ErrorEvent;
+        const error = this.parseError(errorEvent.error || new Error(errorEvent.message));
         this.events.emit("register_error", error);
         this.onClose();
         reject(error);
@@ -117,7 +118,8 @@ export class WsConnection implements IJsonRpcConnection {
     socket.onmessage = (event: MessageEvent) => this.onPayload(event);
     socket.onclose = () => this.onClose();
     socket.onerror = (event: Event) => {
-      const error = this.parseError((event as ErrorEvent).error);
+      const errorEvent = event as ErrorEvent;
+      const error = this.parseError(errorEvent.error || new Error(errorEvent.message));
       this.events.emit("error", error);
     };
     this.socket = socket;


### PR DESCRIPTION
@pedrouid 

When connection is lost parseConnectionError is throwing an error when using 'ws' lib:
```
 Uncaught TypeError: Cannot read property 'message' of undefined
``` 
This exception is causing that the app is not reconnecting after connection is lost.

The problem that if found is that in `event` that is casted on `socket.onerror`, the field `error` is undefined.
To fix that I create an Error object based on `errorEvent.message` on parseError call when `errorEvent.error` is undefined.

This will fix reconnect scenario when using `ws`.

Let me know if I missed something or theres anything that I did not consider to fix it! :)

see:
https://github.com/WalletConnect/walletconnect-utils/issues/8