### PR TITLE
refactor: bump pino pretty version

### DIFF
--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^14.14.7",
     "@types/pino": "^6.3.3",
     "husky": "^4.3.0",
-    "pino-pretty": "^4.3.0",
+    "pino-pretty": "^7.6.0",
     "tslib": "^1.10.0",
     "typescript": "^3.7.5",
     "webpack": "^4.41.6",

--- a/misc/logger/src/constants.ts
+++ b/misc/logger/src/constants.ts
@@ -1,10 +1,5 @@
 export const PINO_LOGGER_DEFAULTS = {
   level: "info",
-  prettyPrint: {
-    colorize: true,
-    translateTime: "SYS:standard",
-    ignore: "pid,hostname",
-  },
 };
 
 export const PINO_CUSTOM_CONTEXT_KEY = "custom_context";

--- a/misc/logger/src/utils.ts
+++ b/misc/logger/src/utils.ts
@@ -6,7 +6,6 @@ export function getDefaultLoggerOptions(opts?: LoggerOptions): LoggerOptions {
   return {
     ...opts,
     level: opts?.level || PINO_LOGGER_DEFAULTS.level,
-    prettyPrint: opts?.prettyPrint || PINO_LOGGER_DEFAULTS.prettyPrint,
   };
 }
 


### PR DESCRIPTION
- Updated pino pretty version to `^7.6.0`
- Removed depricated `prettyPrint` configuration