### PR TITLE
refactor: restores waku prefix for backwards compatibility

### DIFF
--- a/misc/relay-api/src/jsonrpc.ts
+++ b/misc/relay-api/src/jsonrpc.ts
@@ -1,6 +1,15 @@
 import { RelayJsonRpc } from "./types";
 
 export const RELAY_JSONRPC: { [protocol: string]: RelayJsonRpc.Methods } = {
+  waku: {
+    info: "waku_info",
+    connect: "waku_connect",
+    disconnect: "waku_disconnect",
+    publish: "waku_publish",
+    subscribe: "waku_subscribe",
+    subscription: "waku_subscription",
+    unsubscribe: "waku_unsubscribe",
+  },
   iridium: {
     info: "iridium_info",
     connect: "iridium_connect",


### PR DESCRIPTION
Restores the v1 `waku_` prefix for backwards compatibility