### PR TITLE
fix(connection): allows for temp increase in maxListeners during regi…

### DIFF
--- a/jsonrpc/http-connection/src/http.ts
+++ b/jsonrpc/http-connection/src/http.ts
@@ -97,7 +97,7 @@ export class HttpConnection implements IJsonRpcConnection {
       const currentMaxListeners = this.events.getMaxListeners();
       if (
         this.events.listenerCount("register_error") >= currentMaxListeners ||
-        this.events.listenerCount("open") === currentMaxListeners
+        this.events.listenerCount("open") >= currentMaxListeners
       ) {
         this.events.setMaxListeners(currentMaxListeners + 1);
       }

--- a/jsonrpc/http-connection/src/http.ts
+++ b/jsonrpc/http-connection/src/http.ts
@@ -96,7 +96,7 @@ export class HttpConnection implements IJsonRpcConnection {
     if (this.registering) {
       const currentMaxListeners = this.events.getMaxListeners();
       if (
-        this.events.listenerCount("register_error") === currentMaxListeners ||
+        this.events.listenerCount("register_error") >= currentMaxListeners ||
         this.events.listenerCount("open") === currentMaxListeners
       ) {
         this.events.setMaxListeners(currentMaxListeners + 1);

--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -87,7 +87,7 @@ export class WsConnection implements IJsonRpcConnection {
     if (this.registering) {
       const currentMaxListeners = this.events.getMaxListeners();
       if (
-        this.events.listenerCount("register_error") === currentMaxListeners ||
+        this.events.listenerCount("register_error") >= currentMaxListeners ||
         this.events.listenerCount("open") === currentMaxListeners
       ) {
         this.events.setMaxListeners(currentMaxListeners + 1);

--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -10,6 +10,9 @@ import {
   parseConnectionError,
 } from "@walletconnect/jsonrpc-utils";
 
+// Source: https://nodejs.org/api/events.html#emittersetmaxlistenersn
+const EVENT_EMITTER_MAX_LISTENERS_DEFAULT = 10;
+
 const WS =
   // @ts-ignore
   typeof global.WebSocket !== "undefined" ? global.WebSocket : require("ws");
@@ -82,11 +85,20 @@ export class WsConnection implements IJsonRpcConnection {
       throw new Error(`Provided URL is not compatible with WebSocket connection: ${url}`);
     }
     if (this.registering) {
+      const currentMaxListeners = this.events.getMaxListeners();
+      if (
+        this.events.listenerCount("register_error") === currentMaxListeners ||
+        this.events.listenerCount("open") === currentMaxListeners
+      ) {
+        this.events.setMaxListeners(currentMaxListeners + 1);
+      }
       return new Promise((resolve, reject) => {
         this.events.once("register_error", error => {
+          this.resetMaxListeners();
           reject(error);
         });
         this.events.once("open", () => {
+          this.resetMaxListeners();
           if (typeof this.socket === "undefined") {
             return reject(new Error("WebSocket connection is missing or invalid"));
           }
@@ -146,6 +158,12 @@ export class WsConnection implements IJsonRpcConnection {
 
   private parseError(e: Error, url = this.url) {
     return parseConnectionError(e, url, "WS");
+  }
+
+  private resetMaxListeners() {
+    if (this.events.getMaxListeners() > EVENT_EMITTER_MAX_LISTENERS_DEFAULT) {
+      this.events.setMaxListeners(EVENT_EMITTER_MAX_LISTENERS_DEFAULT);
+    }
   }
 }
 

--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -88,7 +88,7 @@ export class WsConnection implements IJsonRpcConnection {
       const currentMaxListeners = this.events.getMaxListeners();
       if (
         this.events.listenerCount("register_error") >= currentMaxListeners ||
-        this.events.listenerCount("open") === currentMaxListeners
+        this.events.listenerCount("open") >= currentMaxListeners
       ) {
         this.events.setMaxListeners(currentMaxListeners + 1);
       }


### PR DESCRIPTION
Resolves https://github.com/WalletConnect/walletconnect-monorepo/issues/1177

## Context

1.  `Subscriber` resubscribes to all existing subscriptions [here](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/core/src/controllers/subscriber.ts#L304)
2. `JsonRpcProvider.open` is called for each subscription, where one of two scenarios happens in the underlying `ws-connection/http-connection` based on the branching in  [`register`](https://github.com/WalletConnect/walletconnect-utils/blob/master/jsonrpc/ws-connection/src/ws.ts#L84):
	1. If this is the first subscription (at index 0), it will call the actual HTTP/WS `open`
	2. If this is a subsequent subscription and the connection registration is in progress (i.e. `this.registering === true`), we give this subscription a `Promise` with `once` listeners for `open` and `register_error` inside.

**3. Since `EventEmitter`'s default `maxListeners` is set at `10`, any scenario where the SDK on top accumulates 11+ subscriptions will trigger this warning, since we temporarily add more than 10 `.once` listeners on both `open` and `register_error`**


## Solution

Since this is expected behaviour (each subscription has temporary listeners to know when the socket is available), it makes sense to temporarily increment `maxListeners` where needed during registration, resetting it after the promises resolve/the connection has opened.

This avoids us displaying an unnecessary warning and confusing end users integrating our SDKs.