### PR TITLE
fix: multiple persisted DBs

### DIFF
--- a/misc/keyvaluestorage/.gitignore
+++ b/misc/keyvaluestorage/.gitignore
@@ -2,4 +2,4 @@
 .DS_Store
 node_modules
 dist
-walletconnect.db*
+test/dbs/*

--- a/misc/keyvaluestorage/package.json
+++ b/misc/keyvaluestorage/package.json
@@ -35,7 +35,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
-    "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
+    "test": "rm -rf ./test/dbs/* && env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
   },
   "dependencies": {

--- a/misc/keyvaluestorage/src/node-js/index.ts
+++ b/misc/keyvaluestorage/src/node-js/index.ts
@@ -4,6 +4,8 @@ import { IKeyValueStorage, KeyValueStorageOptions } from "../shared";
 
 import Db from "./db";
 
+const DB_NAME = "walletconnect.db";
+
 export class KeyValueStorage implements IKeyValueStorage {
   private db;
   private database;
@@ -15,7 +17,7 @@ export class KeyValueStorage implements IKeyValueStorage {
       this.inMemory = true;
     }
     const instance = Db.create({
-      ...opts,
+      db: opts?.database || opts?.table || DB_NAME,
       callback: this.databaseInitialize,
     });
     this.db = instance.database;


### PR DESCRIPTION
Fix for the nodejs storage where the singleton implementation was not allowing the initialization of multiple persisted DBs.

The PR includes:
- fix for the said issue
- a test to make sure this scenario is covered
- tidying up the test dbs 
