### PR TITLE
fix: pino export

### DIFF
--- a/misc/logger/src/index.ts
+++ b/misc/logger/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./constants";
-export * from "./utils";
+import * as constants from "./constants";
+import * as utils from "./utils";
 import pino from "pino";
-module.exports = { pino };
+module.exports = { pino, ...constants, ...utils };

--- a/misc/logger/src/index.ts
+++ b/misc/logger/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./constants";
 export * from "./utils";
-export * from "pino";
+import pino from "pino";
+module.exports = { pino };

--- a/misc/logger/src/index.ts
+++ b/misc/logger/src/index.ts
@@ -1,4 +1,5 @@
-import * as constants from "./constants";
-import * as utils from "./utils";
-import pino from "pino";
-module.exports = { pino, ...constants, ...utils };
+export * from "./constants";
+export * from "./utils";
+export type { Logger } from "pino";
+import { default as pino } from "pino";
+export { pino };


### PR DESCRIPTION
PR to fix an issue where `pino` was not re-exported correctly thus making it unusable when imported from `@walletconnect/logger`

- fix default export `pino`
- fix exporting `Logger` type

### Usage
`import  { pino } from "@walletconnect/logger";`
`import type { Logger } from "@walletconnect/logger";`

### testing
Canary release: `@walletconnect/logger@2.0.0-rc-be5347f3`
dogfooding in monorepo & web-examples