### PR TITLE
fix(ws): ensure we emit a meaningful error msg if `socket.onerror` returns none

### DIFF
--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -126,7 +126,8 @@ export class WsConnection implements IJsonRpcConnection {
         resolve(socket);
       };
       socket.onerror = (event: Event) => {
-        const error = this.parseError((event as ErrorEvent).error);
+        const errorEvent = event as ErrorEvent;
+        const error = this.parseError(errorEvent.error || new Error(errorEvent.message));
         this.events.emit("register_error", error);
         this.onClose();
         reject(error);
@@ -138,7 +139,8 @@ export class WsConnection implements IJsonRpcConnection {
     socket.onmessage = (event: MessageEvent) => this.onPayload(event);
     socket.onclose = () => this.onClose();
     socket.onerror = (event: Event) => {
-      const error = this.parseError((event as ErrorEvent).error);
+      const errorEvent = event as ErrorEvent;
+      const error = this.parseError(errorEvent.error || new Error(errorEvent.message));
       this.events.emit("error", error);
     };
     this.socket = socket;

--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -83,7 +83,7 @@ export class WsConnection implements IJsonRpcConnection {
     try {
       this.socket.send(safeJsonStringify(payload));
     } catch (e) {
-      this.onError(payload.id, e);
+      this.onError(payload.id, e as Error);
     }
   }
 
@@ -127,7 +127,9 @@ export class WsConnection implements IJsonRpcConnection {
       };
       socket.onerror = (event: Event) => {
         const errorEvent = event as ErrorEvent;
-        const error = this.parseError(errorEvent.error || new Error(errorEvent.message));
+        const error = this.parseError(
+          errorEvent.error || new Error(`WebSocket connection failed for URL: ${url}`),
+        );
         this.events.emit("register_error", error);
         this.onClose();
         reject(error);
@@ -140,7 +142,9 @@ export class WsConnection implements IJsonRpcConnection {
     socket.onclose = () => this.onClose();
     socket.onerror = (event: Event) => {
       const errorEvent = event as ErrorEvent;
-      const error = this.parseError(errorEvent.error || new Error(errorEvent.message));
+      const error = this.parseError(
+        errorEvent.error || new Error(`WebSocket connection failed for URL: ${this.url}`),
+      );
       this.events.emit("error", error);
     };
     this.socket = socket;

--- a/jsonrpc/ws-connection/test/index.test.ts
+++ b/jsonrpc/ws-connection/test/index.test.ts
@@ -1,11 +1,44 @@
 import "mocha";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { WsConnection } from "./../src/ws";
+import { FULL_RELAY_WS_URL, WSS_HOST, WS_HOST } from "./shared/values";
 
 chai.use(chaiAsPromised);
 
 describe("@walletconnect/jsonrpc-ws-connection", () => {
-  it("needs tests", async () => {
-    // needs tests
+  describe("init", () => {
+    it("does not initialise with an invalid `ws` string", async () => {
+      chai
+        .expect(() => new WsConnection("invalid"))
+        .to.throw("Provided URL is not compatible with WebSocket connection: invalid");
+    });
+    it("initialises with a `ws:` string", async () => {
+      const conn = new WsConnection(WS_HOST);
+      chai.expect(conn instanceof WsConnection).to.be.true;
+    });
+    it("initialises with a `wss:` string", async () => {
+      const conn = new WsConnection(WSS_HOST);
+      chai.expect(conn instanceof WsConnection).to.be.true;
+    });
+  });
+
+  describe("open", () => {
+    it("can open a connection with a valid relay `wss:` URL", async () => {
+      const conn = new WsConnection(FULL_RELAY_WS_URL);
+
+      chai.expect(conn.connected).to.be.false;
+      await conn.open();
+      chai.expect(conn.connected).to.be.true;
+    });
+    it("surfaces an error if `wss:` URL is valid but connection cannot be made", async () => {
+      const conn = new WsConnection(WSS_HOST);
+      try {
+        await conn.open();
+      } catch (error) {
+        chai.expect(error instanceof Error).to.be.true;
+        chai.expect(error.message).to.equal("Unexpected server response: 400");
+      }
+    });
   });
 });

--- a/jsonrpc/ws-connection/test/shared/values.ts
+++ b/jsonrpc/ws-connection/test/shared/values.ts
@@ -1,0 +1,4 @@
+export const WS_HOST = "ws://staging.relay.walletconnect.com";
+export const WSS_HOST = "wss://staging.relay.walletconnect.com";
+export const FULL_RELAY_WS_URL =
+  "wss://staging.relay.walletconnect.com/?auth=eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWt2TmcxSGZEelpOYWU4QXhBS2hSMVl4dGppUjJMd1RuTk5MN2J6RXdrbm9zbiIsInN1YiI6ImViYTliMmVlYjlkOGQwZDc5NmZiZDA5NGFiYTVlYjcyZTU3YjQ0M2JhNjhmYTBlNGIzYmYzZGNjZDc3NDdjNjAiLCJhdWQiOiJ3c3M6Ly9zdGFnaW5nLnJlbGF5LndhbGxldGNvbm5lY3QuY29tIiwiaWF0IjoxNjY5MTEyNzczLCJleHAiOjE2NjkxOTkxNzN9.TZk21ZkyTRDIgFxxs3JTvmOUpds9CDtJKxpEdH1NVnBwOrwu2m-PAtOd93RnVXU3cDEtyxNEtdJ9RIh5GBLTDw&projectId=e899c82be21d4acca2c8aec45e893598";

--- a/misc/logger/src/index.ts
+++ b/misc/logger/src/index.ts
@@ -1,5 +1,6 @@
+/* eslint-disable-next-line import/no-named-default */
+import { default as pino } from "pino";
 export * from "./constants";
 export * from "./utils";
 export type { Logger } from "pino";
-import { default as pino } from "pino";
 export { pino };


### PR DESCRIPTION
Builds on top of #18. Fixes #8.

The event returned by the browser `WebSocket` implementation is generic/does not contain an `error` or `message` key. We return a generic error with the attempted URL in this case.

See my comment here for deeper context: https://github.com/WalletConnect/walletconnect-utils/pull/18#issuecomment-1323644463

Also:
* Adds test suite for `jsonrpc-ws-connection` with basic sanity checks. Can/should be expanded on later.