### PR TITLE
fix: ws tests

### DIFF
--- a/jsonrpc/ws-connection/package.json
+++ b/jsonrpc/ws-connection/package.json
@@ -43,8 +43,6 @@
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.3",
     "@walletconnect/safe-json": "^1.0.0",
-    "@walletconnect/relay-auth": "^1.0.2",
-    "@walletconnect/utils": "^2.1.3",
     "ws": "^7.5.1"
   },
   "devDependencies": {
@@ -79,6 +77,8 @@
     "prettier": "^1.19.1",
     "typescript": "^3.7.5",
     "webpack": "^4.41.6",
-    "webpack-cli": "^3.3.11"
+    "webpack-cli": "^3.3.11",
+    "@walletconnect/relay-auth": "^1.0.2",
+    "@walletconnect/utils": "^2.1.3"
   }
 }

--- a/jsonrpc/ws-connection/package.json
+++ b/jsonrpc/ws-connection/package.json
@@ -43,6 +43,8 @@
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.3",
     "@walletconnect/safe-json": "^1.0.0",
+    "@walletconnect/relay-auth": "^1.0.2",
+    "@walletconnect/utils": "^2.1.3",
     "ws": "^7.5.1"
   },
   "devDependencies": {

--- a/jsonrpc/ws-connection/test/index.test.ts
+++ b/jsonrpc/ws-connection/test/index.test.ts
@@ -2,9 +2,43 @@ import "mocha";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { WsConnection } from "./../src/ws";
-import { FULL_RELAY_WS_URL, WSS_HOST, WS_HOST } from "./shared/values";
+import { RELAY_URL } from "./shared/values";
+import * as relayAuth from "@walletconnect/relay-auth";
+import { toString } from "uint8arrays";
+import { randomBytes } from "@stablelib/random";
+import { formatRelayRpcUrl } from "@walletconnect/utils";
+import { version } from "@walletconnect/utils/package.json";
+import { fromString } from "uint8arrays/from-string";
 
 chai.use(chaiAsPromised);
+
+const BASE16 = "base16";
+
+function generateRandomBytes32(): string {
+  const random = randomBytes(32);
+  return toString(random, BASE16);
+}
+
+const signJWT = async (aud: string) => {
+  const keyPair = relayAuth.generateKeyPair(fromString(generateRandomBytes32(), BASE16));
+  const sub = generateRandomBytes32();
+  const ttl = 5000; //5 seconds
+  const jwt = await relayAuth.signJWT(sub, aud, ttl, keyPair);
+
+  return jwt;
+};
+
+const formatRelayUrl = async () => {
+  const auth = await signJWT(RELAY_URL);
+  return formatRelayRpcUrl({
+    protocol: "wc",
+    version: 2,
+    sdkVersion: version,
+    relayUrl: RELAY_URL,
+    projectId: "3cbaa32f8fbf3cdcc87d27ca1fa68069",
+    auth,
+  });
+};
 
 describe("@walletconnect/jsonrpc-ws-connection", () => {
   describe("init", () => {
@@ -14,25 +48,25 @@ describe("@walletconnect/jsonrpc-ws-connection", () => {
         .to.throw("Provided URL is not compatible with WebSocket connection: invalid");
     });
     it("initialises with a `ws:` string", async () => {
-      const conn = new WsConnection(WS_HOST);
+      const conn = new WsConnection(`ws://${await formatRelayUrl()}`);
       chai.expect(conn instanceof WsConnection).to.be.true;
     });
     it("initialises with a `wss:` string", async () => {
-      const conn = new WsConnection(WSS_HOST);
+      const conn = new WsConnection(`wss://${await formatRelayUrl()}`);
       chai.expect(conn instanceof WsConnection).to.be.true;
     });
   });
 
   describe("open", () => {
     it("can open a connection with a valid relay `wss:` URL", async () => {
-      const conn = new WsConnection(FULL_RELAY_WS_URL);
+      const conn = new WsConnection(`wss://${await formatRelayUrl()}`);
 
       chai.expect(conn.connected).to.be.false;
       await conn.open();
       chai.expect(conn.connected).to.be.true;
     });
     it("surfaces an error if `wss:` URL is valid but connection cannot be made", async () => {
-      const conn = new WsConnection(WSS_HOST);
+      const conn = new WsConnection(`wss://${await formatRelayUrl()}`);
       try {
         await conn.open();
       } catch (error) {

--- a/jsonrpc/ws-connection/test/shared/values.ts
+++ b/jsonrpc/ws-connection/test/shared/values.ts
@@ -1,4 +1,1 @@
-export const WS_HOST = "ws://staging.relay.walletconnect.com";
-export const WSS_HOST = "wss://staging.relay.walletconnect.com";
-export const FULL_RELAY_WS_URL =
-  "wss://staging.relay.walletconnect.com?auth=eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJkaWQ6a2V5Ono2TWttbmVQWnRTNjZ4M0ZIWGFVbmtGZ3NoZUU1SEJ6QkhDV1lmUVFUM2dLcHMxSCIsInN1YiI6Ijk2OWUxYzU5MTg3ZDU4NDYyMzkwYTE4NzExYzZmMDlmOTZiNGE5NDNhOWQ5ZjBkMmNiMTdkYWQ2MTAxY2NiOTgiLCJhdWQiOiJ3c3M6Ly9zdGFnaW5nLnJlbGF5LndhbGxldGNvbm5lY3QuY29tIiwiaWF0IjoxNjY5Mjg4Mjg1LCJleHAiOjE2NjkyOTMyODV9.zGoLD3Pw9mQcblmIdEsPrBCjZG9DAr2nBC-b53oDOJBfiJCTUihSzdov5RQCgdzJtQNK0ueaxpnpk2umyxpYDA&projectId=3cbaa32f8fbf3cdcc87d27ca1fa68069&ua=wc-2%2Fjs-2.1.3%2Flinux-16.16.0%2Fnode";
+export const RELAY_URL = "staging.relay.walletconnect.com";


### PR DESCRIPTION
Fix for ws tests to generate new auth before attempting to crease socket with relay similarly as in https://github.com/WalletConnect/walletconnect-utils/pull/39

That is needed because using a pre-built auth string fails as it has an expiry