### PR TITLE
fix: ws error handler in node

### DIFF
--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -130,13 +130,6 @@ export class WsConnection implements IJsonRpcConnection {
         };
       } else {
         (socket as any).on("error", (errorEvent: any) => {
-          // eslint-disable-next-line no-console
-          console.log(
-            "ws: captured socket on error",
-            errorEvent,
-            errorEvent.message,
-            /socket hang up/i.test(errorEvent.message),
-          );
           reject(this.emitError(errorEvent));
         });
       }

--- a/jsonrpc/ws-connection/test/index.test.ts
+++ b/jsonrpc/ws-connection/test/index.test.ts
@@ -48,25 +48,25 @@ describe("@walletconnect/jsonrpc-ws-connection", () => {
         .to.throw("Provided URL is not compatible with WebSocket connection: invalid");
     });
     it("initialises with a `ws:` string", async () => {
-      const conn = new WsConnection(`ws://${await formatRelayUrl()}`);
+      const conn = new WsConnection(await formatRelayUrl());
       chai.expect(conn instanceof WsConnection).to.be.true;
     });
     it("initialises with a `wss:` string", async () => {
-      const conn = new WsConnection(`wss://${await formatRelayUrl()}`);
+      const conn = new WsConnection(await formatRelayUrl());
       chai.expect(conn instanceof WsConnection).to.be.true;
     });
   });
 
   describe("open", () => {
     it("can open a connection with a valid relay `wss:` URL", async () => {
-      const conn = new WsConnection(`wss://${await formatRelayUrl()}`);
+      const conn = new WsConnection(await formatRelayUrl());
 
       chai.expect(conn.connected).to.be.false;
       await conn.open();
       chai.expect(conn.connected).to.be.true;
     });
     it("surfaces an error if `wss:` URL is valid but connection cannot be made", async () => {
-      const conn = new WsConnection(`wss://${await formatRelayUrl()}`);
+      const conn = new WsConnection(await formatRelayUrl());
       try {
         await conn.open();
       } catch (error) {

--- a/jsonrpc/ws-connection/test/shared/values.ts
+++ b/jsonrpc/ws-connection/test/shared/values.ts
@@ -1,1 +1,1 @@
-export const RELAY_URL = "staging.relay.walletconnect.com";
+export const RELAY_URL = "wss://staging.relay.walletconnect.com";


### PR DESCRIPTION
Errors thrown in `ws` library such as `socket hang up` are not handled by the `WebSocket` api `onerror`. This was causing unhandled exceptions.

New error handling depending on the environment:
- In browser - `socket.onerror`
- in node - `socket.on('error')` 

## Tested?
Manual testing
Integration tests
Canary has been running this code for ~2 weeks