### PR TITLE
feat(ws-connection): forward CloseEvent, adds test for useOnCloseEvent

### DIFF
--- a/jsonrpc/provider/src/provider.ts
+++ b/jsonrpc/provider/src/provider.ts
@@ -103,8 +103,8 @@ export class JsonRpcProvider extends IJsonRpcProvider {
   }
 
   protected onClose(event?: CloseEvent): void {
-    // Anything other than 1000 is an abnormal closure -> also emit an error in this case.
-    if (event && event.code !== 1000) {
+    // Code 3000 indicates an abnormal closure signalled by the relay -> emit an error in this case.
+    if (event && event.code === 3000) {
       this.events.emit(
         "error",
         new Error(

--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -77,8 +77,8 @@ export class WsConnection implements IJsonRpcConnection {
         return;
       }
 
-      this.socket.onclose = () => {
-        this.onClose();
+      this.socket.onclose = event => {
+        this.onClose(event);
         resolve();
       };
 
@@ -150,16 +150,16 @@ export class WsConnection implements IJsonRpcConnection {
 
   private onOpen(socket: WebSocket) {
     socket.onmessage = (event: MessageEvent) => this.onPayload(event);
-    socket.onclose = () => this.onClose();
+    socket.onclose = event => this.onClose(event);
     this.socket = socket;
     this.registering = false;
     this.events.emit("open");
   }
 
-  private onClose() {
+  private onClose(event: CloseEvent) {
     this.socket = undefined;
     this.registering = false;
-    this.events.emit("close");
+    this.events.emit("close", event);
   }
 
   private onPayload(e: { data: any }) {


### PR DESCRIPTION
## Context

- Towards https://github.com/WalletConnect/walletconnect-monorepo/issues/2091
- Forward the currently ignored `CloseEvent`
- Emit an error when an abnormal close is detected

## How has this been tested

- Unit tests
- Integrated downstream into `core` and tested regular WS conn and failure cases in React sample wallet via following canaries:
	- `"@walletconnect/jsonrpc-ws-connection": "1.0.9-f14036a"`
	- `"@walletconnect/jsonrpc-provider": "1.0.8-f37f36d"`
	- `"@walletconnect/core": "2.4.9-ff902def"`
- Tested `provider.disconnect()` (close code `1005`)
- Tested `provider.transportClose()` (close code `1005`)
- Tested automatic relay rebalancing (close code `4010`)