### PR TITLE
chore(scripts): adds publishing scripts to all pkgs

### DIFF
--- a/browser/window-getters/package.json
+++ b/browser/window-getters/package.json
@@ -34,7 +34,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",

--- a/browser/window-getters/package.json
+++ b/browser/window-getters/package.json
@@ -33,7 +33,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",

--- a/browser/window-getters/package.json
+++ b/browser/window-getters/package.json
@@ -32,7 +32,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",

--- a/browser/window-metadata/package.json
+++ b/browser/window-metadata/package.json
@@ -33,7 +33,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/window-getters": "^1.0.1",

--- a/browser/window-metadata/package.json
+++ b/browser/window-metadata/package.json
@@ -34,7 +34,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/window-getters": "^1.0.1",

--- a/browser/window-metadata/package.json
+++ b/browser/window-metadata/package.json
@@ -32,7 +32,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/window-getters": "^1.0.1",

--- a/crypto/crypto/package.json
+++ b/crypto/crypto/package.json
@@ -38,7 +38,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/encoding": "^1.0.2",

--- a/crypto/crypto/package.json
+++ b/crypto/crypto/package.json
@@ -37,7 +37,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/encoding": "^1.0.2",

--- a/crypto/crypto/package.json
+++ b/crypto/crypto/package.json
@@ -36,7 +36,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/encoding": "^1.0.2",

--- a/crypto/ecies-25519/package.json
+++ b/crypto/ecies-25519/package.json
@@ -44,7 +44,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@stablelib/x25519": "^1.0.2",

--- a/crypto/ecies-25519/package.json
+++ b/crypto/ecies-25519/package.json
@@ -42,7 +42,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@stablelib/x25519": "^1.0.2",

--- a/crypto/ecies-25519/package.json
+++ b/crypto/ecies-25519/package.json
@@ -43,7 +43,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@stablelib/x25519": "^1.0.2",

--- a/crypto/randombytes/package.json
+++ b/crypto/randombytes/package.json
@@ -35,7 +35,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/encoding": "^1.0.2",

--- a/crypto/randombytes/package.json
+++ b/crypto/randombytes/package.json
@@ -36,7 +36,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/encoding": "^1.0.2",

--- a/crypto/randombytes/package.json
+++ b/crypto/randombytes/package.json
@@ -34,7 +34,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --exit -r ts-node/register -r jsdom-global/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/encoding": "^1.0.2",

--- a/jsonrpc/http-connection/package.json
+++ b/jsonrpc/http-connection/package.json
@@ -40,7 +40,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/http-connection/package.json
+++ b/jsonrpc/http-connection/package.json
@@ -39,7 +39,8 @@
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/http-connection/package.json
+++ b/jsonrpc/http-connection/package.json
@@ -38,7 +38,8 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/provider/package.json
+++ b/jsonrpc/provider/package.json
@@ -41,7 +41,8 @@
     "test:watch": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 3000 --exit -r ts-node/register --watch --watch-files . ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/provider/package.json
+++ b/jsonrpc/provider/package.json
@@ -40,7 +40,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "test:watch": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 3000 --exit -r ts-node/register --watch --watch-files . ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/provider/package.json
+++ b/jsonrpc/provider/package.json
@@ -39,7 +39,8 @@
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "test:watch": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 3000 --exit -r ts-node/register --watch --watch-files . ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/types/package.json
+++ b/jsonrpc/types/package.json
@@ -39,7 +39,8 @@
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "keyvaluestorage-interface": "^1.0.0",

--- a/jsonrpc/types/package.json
+++ b/jsonrpc/types/package.json
@@ -40,7 +40,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "keyvaluestorage-interface": "^1.0.0",

--- a/jsonrpc/types/package.json
+++ b/jsonrpc/types/package.json
@@ -38,7 +38,8 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "keyvaluestorage-interface": "^1.0.0",

--- a/jsonrpc/utils/package.json
+++ b/jsonrpc/utils/package.json
@@ -38,7 +38,8 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha -r ts-node/register ./test/**/*.{test,spec}.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/environment": "^1.0.1",

--- a/jsonrpc/utils/package.json
+++ b/jsonrpc/utils/package.json
@@ -39,7 +39,8 @@
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha -r ts-node/register ./test/**/*.{test,spec}.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/environment": "^1.0.1",

--- a/jsonrpc/utils/package.json
+++ b/jsonrpc/utils/package.json
@@ -40,7 +40,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha -r ts-node/register ./test/**/*.{test,spec}.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/environment": "^1.0.1",

--- a/jsonrpc/ws-connection/package.json
+++ b/jsonrpc/ws-connection/package.json
@@ -40,7 +40,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/ws-connection/package.json
+++ b/jsonrpc/ws-connection/package.json
@@ -39,7 +39,8 @@
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/jsonrpc/ws-connection/package.json
+++ b/jsonrpc/ws-connection/package.json
@@ -38,7 +38,8 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",

--- a/misc/cacao/package.json
+++ b/misc/cacao/package.json
@@ -15,7 +15,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-utils",

--- a/misc/cacao/package.json
+++ b/misc/cacao/package.json
@@ -14,7 +14,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-utils",

--- a/misc/cacao/package.json
+++ b/misc/cacao/package.json
@@ -16,7 +16,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/walletconnect-utils",

--- a/misc/encoding/package.json
+++ b/misc/encoding/package.json
@@ -37,7 +37,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/encoding/package.json
+++ b/misc/encoding/package.json
@@ -39,7 +39,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/encoding/package.json
+++ b/misc/encoding/package.json
@@ -38,7 +38,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/environment/package.json
+++ b/misc/environment/package.json
@@ -35,7 +35,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/environment/package.json
+++ b/misc/environment/package.json
@@ -34,7 +34,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/environment/package.json
+++ b/misc/environment/package.json
@@ -33,7 +33,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/events/package.json
+++ b/misc/events/package.json
@@ -39,7 +39,8 @@
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "keyvaluestorage-interface": "^1.0.0",

--- a/misc/events/package.json
+++ b/misc/events/package.json
@@ -40,7 +40,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "keyvaluestorage-interface": "^1.0.0",

--- a/misc/events/package.json
+++ b/misc/events/package.json
@@ -38,7 +38,8 @@
     "build:esm": "npx tsc -p tsconfig.esm.json",
     "build": "run-s build:pre build:cjs build:esm build:umd",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "keyvaluestorage-interface": "^1.0.0",

--- a/misc/heartbeat/package.json
+++ b/misc/heartbeat/package.json
@@ -35,7 +35,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "@walletconnect/events": "^1.0.1",

--- a/misc/heartbeat/package.json
+++ b/misc/heartbeat/package.json
@@ -36,7 +36,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "@walletconnect/events": "^1.0.1",

--- a/misc/heartbeat/package.json
+++ b/misc/heartbeat/package.json
@@ -34,7 +34,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "@walletconnect/events": "^1.0.1",

--- a/misc/keyvaluestorage/package.json
+++ b/misc/keyvaluestorage/package.json
@@ -36,7 +36,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "rm -rf ./test/dbs/* && env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "dependencies": {
     "safe-json-utils": "^1.1.1",

--- a/misc/keyvaluestorage/package.json
+++ b/misc/keyvaluestorage/package.json
@@ -38,7 +38,8 @@
     "test": "rm -rf ./test/dbs/* && env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "dependencies": {
     "safe-json-utils": "^1.1.1",

--- a/misc/keyvaluestorage/package.json
+++ b/misc/keyvaluestorage/package.json
@@ -37,7 +37,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "rm -rf ./test/dbs/* && env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "dependencies": {
     "safe-json-utils": "^1.1.1",

--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -35,7 +35,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -34,7 +34,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -33,7 +33,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/safe-json/package.json
+++ b/misc/safe-json/package.json
@@ -34,7 +34,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",

--- a/misc/safe-json/package.json
+++ b/misc/safe-json/package.json
@@ -35,7 +35,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",

--- a/misc/safe-json/package.json
+++ b/misc/safe-json/package.json
@@ -36,7 +36,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/bn.js": "4.11.6",

--- a/misc/time/package.json
+++ b/misc/time/package.json
@@ -36,7 +36,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/time/package.json
+++ b/misc/time/package.json
@@ -35,7 +35,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/misc/time/package.json
+++ b/misc/time/package.json
@@ -34,7 +34,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/relay/relay-api/package.json
+++ b/relay/relay-api/package.json
@@ -36,7 +36,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/relay/relay-api/package.json
+++ b/relay/relay-api/package.json
@@ -35,7 +35,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/relay/relay-api/package.json
+++ b/relay/relay-api/package.json
@@ -34,7 +34,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/relay/relay-auth/package.json
+++ b/relay/relay-auth/package.json
@@ -37,7 +37,8 @@
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
     "npm-publish:latest": "npm publish --access public --tag latest",
-    "npm-publish:canary": "npm publish --access public --tag canary"
+    "npm-publish:canary": "npm publish --access public --tag canary",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/relay/relay-auth/package.json
+++ b/relay/relay-auth/package.json
@@ -36,7 +36,8 @@
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
     "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
-    "npm-publish:latest": "npm publish --access public --tag latest"
+    "npm-publish:latest": "npm publish --access public --tag latest",
+    "npm-publish:canary": "npm publish --access public --tag canary"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/relay/relay-auth/package.json
+++ b/relay/relay-auth/package.json
@@ -35,7 +35,8 @@
     "build:umd": "webpack",
     "build": "run-s clean build:cjs build:esm build:umd ",
     "test": "env TS_NODE_PROJECT=\"tsconfig.cjs.json\" mocha --timeout 5000 --exit -r ts-node/register ./test/**/*.test.ts",
-    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'"
+    "lint": "eslint -c '../../.eslintrc' --fix './src/**/*.ts'",
+    "npm-publish:latest": "npm publish --access public --tag latest"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",


### PR DESCRIPTION
* Done via e.g. `npx lerna exec -- 'npm set-script prepublishOnly "npm run test && npm run build"'`