### PR TITLE
fix(did-jwt): use multiformats@9.9.0

### DIFF
--- a/misc/did-jwt/package.json
+++ b/misc/did-jwt/package.json
@@ -41,6 +41,6 @@
   "dependencies": {
     "@noble/ed25519": "1.7.3",
     "bs58": "5.0.0",
-    "multiformats": "11.0.2"
+    "multiformats": "9.9.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "lodash.isequal": "4.5.0",
         "lokijs": "^1.5.12",
         "mocha": "^8.1.3",
-        "multiformats": "11.0.2",
+        "multiformats": "9.9.0",
         "pino": "7.11.0",
         "pino-pretty": "^7.6.0",
         "prettier": "^1.19.1",
@@ -9724,11 +9724,6 @@
       "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
       "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA=="
     },
-    "node_modules/did-jwt/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
     "node_modules/did-resolver": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-3.2.2.tgz",
@@ -15196,11 +15191,6 @@
         "varint": "^6.0.0"
       }
     },
-    "node_modules/key-did-resolver/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-    },
     "node_modules/keyvaluestorage-interface": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
@@ -18015,13 +18005,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -18131,11 +18117,6 @@
         "multiformats": "^9.6.5",
         "uint8arrays": "^2.1.4"
       }
-    },
-    "node_modules/nist-weierstrauss/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/nist-weierstrauss/node_modules/uint8arrays": {
       "version": "2.1.10",
@@ -22973,11 +22954,6 @@
       "dependencies": {
         "multiformats": "^9.4.2"
       }
-    },
-    "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -31939,11 +31915,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
           "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA=="
-        },
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
         }
       }
     },
@@ -36096,13 +36067,6 @@
         "nist-weierstrauss": "^1.3.0",
         "uint8arrays": "^3.0.0",
         "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        }
       }
     },
     "keyvaluestorage-interface": {
@@ -38371,9 +38335,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "multimatch": {
       "version": "5.0.0",
@@ -38465,11 +38429,6 @@
         "uint8arrays": "^2.1.4"
       },
       "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        },
         "uint8arrays": {
           "version": "2.1.10",
           "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
@@ -42284,13 +42243,6 @@
       "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "requires": {
         "multiformats": "^9.4.2"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        }
       }
     },
     "unbox-primitive": {


### PR DESCRIPTION
* Getting blocked on resolution errors for the multiformats import from `did-jwt` as dep both when running tests and in the Push next.js samples:

```
Error: Package subpath './bases/base58' is not defined by "exports" in /Users/bk/repos/walletconnect/push-client-js/node_modules/@walletconnect/did-jwt/node_modules/multiformats/package.json
 ❯ Object.<anonymous> ../../node_modules/@walletconnect/did-jwt/dist/cjs/did-jwt.js:5:18
```

- Turns out they moved to ESM-only publishing in v10.x.x (https://github.com/multiformats/js-multiformats/tags), which breaks any CJS-facing usage for us.
- Using `9.9.0` fixes the resolution issues, and we do not need any of the changes made in the higher major versions since we only use a single function `base58btc`