### PR TITLE
feat: bigint rpc_id

### DIFF
--- a/jsonrpc/provider/src/provider.ts
+++ b/jsonrpc/provider/src/provider.ts
@@ -9,6 +9,7 @@ import {
   isJsonRpcResponse,
   formatJsonRpcRequest,
   isJsonRpcError,
+  getBigIntRpcId,
 } from "@walletconnect/jsonrpc-utils";
 
 export class JsonRpcProvider extends IJsonRpcProvider {
@@ -54,7 +55,14 @@ export class JsonRpcProvider extends IJsonRpcProvider {
     request: RequestArguments<Params>,
     context?: any,
   ): Promise<Result> {
-    return this.requestStrict(formatJsonRpcRequest(request.method, request.params || []), context);
+    return this.requestStrict(
+      formatJsonRpcRequest(
+        request.method,
+        request.params || [],
+        getBigIntRpcId().toString() as any,
+      ), // casting to any is required in order to use BigInt as rpcId
+      context,
+    );
   }
 
   // ---------- Protected ----------------------------------------------- //

--- a/jsonrpc/utils/src/format.ts
+++ b/jsonrpc/utils/src/format.ts
@@ -2,10 +2,14 @@ import { getError, getErrorByCode, isReservedErrorCode, isServerErrorCode } from
 import { INTERNAL_ERROR, SERVER_ERROR } from "./constants";
 import { ErrorResponse, JsonRpcError, JsonRpcRequest, JsonRpcResult } from "./types";
 
-export function payloadId(): number {
-  const date = Date.now() * Math.pow(10, 3);
-  const extra = Math.floor(Math.random() * Math.pow(10, 3));
+export function payloadId(entropy = 3): number {
+  const date = Date.now() * Math.pow(10, entropy);
+  const extra = Math.floor(Math.random() * Math.pow(10, entropy));
   return date + extra;
+}
+
+export function getBigIntRpcId(entropy = 6): bigint {
+  return BigInt(payloadId(entropy));
 }
 
 export function formatJsonRpcRequest<T = any>(

--- a/jsonrpc/utils/test/payloadId.test.ts
+++ b/jsonrpc/utils/test/payloadId.test.ts
@@ -2,7 +2,7 @@ import "mocha";
 import * as chai from "chai";
 import { delay } from "@walletconnect/timestamp";
 
-import { payloadId } from "../src";
+import { getBigIntRpcId, payloadId } from "../src";
 import { findDuplicates } from "./shared";
 
 describe("Payload Id", () => {
@@ -23,6 +23,10 @@ describe("Payload Id", () => {
 
   it("returns an integer with 16 digits", () => {
     chai.expect(payloadId().toString().length).to.equal(16);
+  });
+
+  it("returns an bigint with 19 digits", () => {
+    chai.expect(getBigIntRpcId().toString().length).to.equal(19);
   });
 
   // Context: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER

--- a/jsonrpc/utils/test/payloadId.test.ts
+++ b/jsonrpc/utils/test/payloadId.test.ts
@@ -25,7 +25,7 @@ describe("Payload Id", () => {
     chai.expect(payloadId().toString().length).to.equal(16);
   });
 
-  it("returns an bigint with 19 digits", () => {
+  it("returns a bigint with 19 digits", () => {
     chai.expect(getBigIntRpcId().toString().length).to.equal(19);
   });
 

--- a/misc/safe-json/src/index.ts
+++ b/misc/safe-json/src/index.ts
@@ -1,14 +1,50 @@
+/** JSONStringify & JSONParse used from json-with-bigint */
+/* 
+  Function to serialize data to JSON string.
+  Converts all BigInt values to strings with "n" character at the end.
+*/
+const JSONStringify = data =>
+  JSON.stringify(data, (_, value) =>
+    typeof value === "bigint" ? value.toString() + "n" : value
+  );
+
+/* 
+  Function to parse JSON.
+  If JSON has values in our custom format BigInt (strings with "n" character at the end), we just parse them to BigInt values.
+  If JSON has big number values, but not in our custom format, we copy it, and in a copy we convert those values to our custom format, 
+  then parse them to BigInt values.
+  Other values (not big numbers and not our custom format BigInt values) are not affected and parsed as native JSON.parse() would parse them.
+*/
+const JSONParse = json => {
+  /*
+    Big numbers are found and marked using Regex with this condition:
+    Number's length is bigger than 16 || Number's length is 16 and any numerical digit of the number is greater than that of the Number.MAX_SAFE_INTEGER
+  */
+  const numbersBiggerThanMaxInt = /([\[:])?(\d{17,}|(?:[9](?:[1-9]07199254740991|0[1-9]7199254740991|00[8-9]199254740991|007[2-9]99254740991|007199[3-9]54740991|0071992[6-9]4740991|00719925[5-9]740991|007199254[8-9]40991|0071992547[5-9]0991|00719925474[1-9]991|00719925474099[2-9])))([,\}\]])/g;
+  const serializedData = json.replace(numbersBiggerThanMaxInt, '$1"$2n"$3');
+
+  return JSON.parse(serializedData, (_, value) => {
+    const isCustomFormatBigInt =
+      typeof value === "string" && value.match(/^\d+n$/);
+
+    if (isCustomFormatBigInt)
+      return BigInt(value.substring(0, value.length - 1));
+
+    return value;
+  });
+};
+
 export function safeJsonParse<T = any>(value: string): T | string {
   if (typeof value !== "string") {
     throw new Error(`Cannot safe json parse value of type ${typeof value}`);
   }
   try {
-    return JSON.parse(value);
+    return JSONParse(value);
   } catch {
     return value;
   }
 }
 
 export function safeJsonStringify(value: any): string {
-  return typeof value === "string" ? value : JSON.stringify(value);
+  return typeof value === "string" ? value : JSONStringify(value) || "";
 }

--- a/misc/safe-json/src/index.ts
+++ b/misc/safe-json/src/index.ts
@@ -1,4 +1,7 @@
-/** JSONStringify & JSONParse used from json-with-bigint */
+/**
+ * JSONStringify & JSONParse used from json-with-bigint
+ * source: https://github.com/Ivan-Korolenko/json-with-bigint
+ */
 /* 
   Function to serialize data to JSON string.
   Converts all BigInt values to strings with "n" character at the end.

--- a/misc/safe-json/src/index.ts
+++ b/misc/safe-json/src/index.ts
@@ -20,8 +20,9 @@ const JSONParse = json => {
     Big numbers are found and marked using Regex with this condition:
     Number's length is bigger than 16 || Number's length is 16 and any numerical digit of the number is greater than that of the Number.MAX_SAFE_INTEGER
   */
+  // eslint-disable-next-line no-useless-escape
   const numbersBiggerThanMaxInt = /([\[:])?(\d{17,}|(?:[9](?:[1-9]07199254740991|0[1-9]7199254740991|00[8-9]199254740991|007[2-9]99254740991|007199[3-9]54740991|0071992[6-9]4740991|00719925[5-9]740991|007199254[8-9]40991|0071992547[5-9]0991|00719925474[1-9]991|00719925474099[2-9])))([,\}\]])/g;
-  const serializedData = json.replace(numbersBiggerThanMaxInt, '$1"$2n"$3');
+  const serializedData = json.replace(numbersBiggerThanMaxInt, "$1\"$2n\"$3");
 
   return JSON.parse(serializedData, (_, value) => {
     const isCustomFormatBigInt =

--- a/misc/safe-json/test/index.test.ts
+++ b/misc/safe-json/test/index.test.ts
@@ -25,8 +25,8 @@ describe("@walletconnect/safe-json", () => {
       chai.expect(result).to.eql(invalid);
     });
     it("should handle bigint", () => {
-      const result = safeJsonParse(safeJsonStringify({ biging: BigInt(1) }));
-      chai.expect(result).to.deep.eq({ biging: BigInt(1) });
+      const result = safeJsonParse(safeJsonStringify({ bigint: BigInt(1) }));
+      chai.expect(result).to.deep.eq({ bigint: BigInt(1) });
     });
   });
   describe("safeJsonStringify", () => {

--- a/misc/safe-json/test/index.test.ts
+++ b/misc/safe-json/test/index.test.ts
@@ -24,6 +24,10 @@ describe("@walletconnect/safe-json", () => {
       const result = safeJsonParse(invalid);
       chai.expect(result).to.eql(invalid);
     });
+    it("should handle bigint", () => {
+      const result = safeJsonParse(safeJsonStringify({ biging: BigInt(1) }));
+      chai.expect(result).to.deep.eq({ biging: BigInt(1) });
+    });
   });
   describe("safeJsonStringify", () => {
     it("should return a stringfied json", () => {


### PR DESCRIPTION
Implemented
- util fx to generate `bigint` rpc_id with 19 digits 
- default assigning bigint rpc_id in jsonrpc-provider (client -> server)
- custom JSON parser to handle `bigints` in safe-json 
- tests

After PR is approved we have to release the utils in order
1. safe-json
2. update jsonrpc-provider & jsonrpc-ws-connection with the released safe-json
3. release jsonrpc-provider & jsonrpc-ws-connection with the updated safe-json 