### PR TITLE
feat(types): adds act field to JwtPayload

### DIFF
--- a/misc/did-jwt/package-lock.json
+++ b/misc/did-jwt/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@walletconnect/did-jwt",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@walletconnect/did-jwt",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^4.9.5"

--- a/misc/did-jwt/package.json
+++ b/misc/did-jwt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/did-jwt",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Utilities for creating and handling DID-JWTs",
   "keywords": [
     "did-jwt",

--- a/misc/did-jwt/src/types.ts
+++ b/misc/did-jwt/src/types.ts
@@ -6,10 +6,11 @@ export interface JwtHeader {
 export interface JwtPayload {
   iss: string;
   sub: string;
+  iat: number;
+  exp: number;
+  act: string;
   aud?: string;
   ksu?: string;
   pkh?: string;
   pke?: string;
-  iat: number;
-  exp: number;
 }


### PR DESCRIPTION
## Context
* Required by: https://github.com/WalletConnect/walletconnect-docs/pull/583/
* Required for: https://github.com/WalletConnect/push-client-js/issues/5
* BREAKING CHANGE: this adds `act: string` as a required `JwtPayload` key