### PR TITLE
heartbeat@1.2.1

### DIFF
--- a/misc/heartbeat/package-lock.json
+++ b/misc/heartbeat/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@walletconnect/heartbeat",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@walletconnect/heartbeat",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",

--- a/misc/heartbeat/package.json
+++ b/misc/heartbeat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/heartbeat",
   "description": "HeartBeat",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
- Fixes #50 
- Last published version of heartbeat seems to have unwanted prod deps defined (see linked issue)
- Publishing `1.2.1` to ensure proper deps are pulled
- Tested via canary release: `npm view @walletconnect/heartbeat@1.2.0-a7475d6` 