### PR TITLE
Add getter for identity key

### DIFF
--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -17,6 +17,7 @@ import {
   RegisterIdentityParams,
   ResolveIdentityParams,
   UnregisterIdentityParams,
+  GetIdentityParams,
 } from "./types";
 
 const DEFAULT_KEYSERVER_URL = "https://keys.walletconnect.com";
@@ -166,5 +167,9 @@ export class IdentityKeys implements IIdentityKeys {
       this.core.logger.error(e);
       throw new Error("Failed to resolve identity key");
     }
+  }
+
+  public async getIdentity({ account }: GetIdentityParams): Promise<string> {
+    return this.identityKeys.get(account).identityKeyPub;
   }
 }

--- a/misc/identity-keys/src/types.ts
+++ b/misc/identity-keys/src/types.ts
@@ -14,6 +14,10 @@ export interface UnregisterIdentityParams {
   account: string;
 }
 
+export interface GetIdentityParams {
+  account: string;
+}
+
 export interface IdentityKeychain {
   accountId: string;
   identityKeyPub: string;


### PR DESCRIPTION
# Changes
- Add `getIdentityKey` to prevent having to call `resolveIdentity` to retrieve user's own identity key.