### PR TITLE
Fix unregister using old key format

### DIFF
--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -126,7 +126,7 @@ export class IdentityKeys implements IIdentityKeys {
   public async unregisterIdentity({ account }: UnregisterIdentityParams): Promise<void> {
     try {
       const iat = Date.now();
-      const keys = this.identityKeys.get(`${account}_identityKeys`);
+      const keys = this.identityKeys.get(account);
       const didPublicKey = composeDidPkh(account);
       const unregisterIdentityPayload = {
         iat,


### PR DESCRIPTION
# Changes
- Unregister was using the old `${account}_identityKeys` which we changed to just be `${account}`, so updated it to new format