### PR TITLE
fix(storage): adds missing colon in `IDENTITY_KEYS_STORAGE_PREFIX`

### DIFF
--- a/misc/did-jwt/src/types.ts
+++ b/misc/did-jwt/src/types.ts
@@ -13,4 +13,5 @@ export interface JwtPayload {
   ksu?: string;
   pkh?: string;
   pke?: string;
+  scp?: string;
 }

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -21,7 +21,7 @@ import {
 } from "./types";
 
 const DEFAULT_KEYSERVER_URL = "https://keys.walletconnect.com";
-const IDENTITY_KEYS_STORAGE_PREFIX = "wc@2:identityKeys";
+const IDENTITY_KEYS_STORAGE_PREFIX = "wc@2:identityKeys:";
 
 export class IdentityKeys implements IIdentityKeys {
   private keyserverUrl: string;


### PR DESCRIPTION
## Context

- The storage key currently being created is missing the `:` colon at the end of the prefix, resulting in the key being `wc@2:identityKeys0.3//identityKeys` instead of `wc@2:identityKeys:0.3//identityKeys`
- Also: expands `JwtPayload` type to allow for `scp` (scope) parameter needed for Push JWTs
- Will merge via merge commit to preserve both independent commits

## Follow-ups
- [ ] Publish new patch version of `@walletconnect/identity-keys`
- [ ] Publish new patch version of `@walletconnect/did-jwt`
- [ ] Update chat-client and push-client to use newly published version of the above.
