### PR TITLE
fix(history): aligns @walletconnect/types min version

### DIFF
--- a/misc/history/package-lock.json
+++ b/misc/history/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@walletconnect/core": "^2.7.3",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/types": "^2.7.1",
+        "@walletconnect/types": "^2.7.3",
         "typescript": "^4.9.5"
       }
     },

--- a/misc/history/package.json
+++ b/misc/history/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@walletconnect/core": "^2.7.3",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
-    "@walletconnect/types": "^2.7.1",
+    "@walletconnect/types": "^2.7.3",
     "typescript": "^4.9.5"
   },
   "dependencies": {

--- a/misc/history/src/utils.ts
+++ b/misc/history/src/utils.ts
@@ -28,7 +28,7 @@ export class HistoryClient {
         body: JSON.stringify(payload),
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${await this.getJwt()}`
+          Authorization: `Bearer ${await this.getJwt()}`,
         },
       });
 
@@ -42,7 +42,7 @@ export class HistoryClient {
     const params = new URLSearchParams(entries);
 
     try {
-      const url = `${historyUrl}/messages?${params.toString()}`
+      const url = `${historyUrl}/messages?${params.toString()}`;
       const rs: GetMessagesResponse = await (
         await fetch(url, {
           method: "GET",


### PR DESCRIPTION
## Context

- `@walletconnect/types@2.7.1` was being specified instead of being in line with others `@2.7.3`
- Caused TS errors: https://github.com/WalletConnect/walletconnect-utils/actions/runs/5121822955/jobs/9266156478#step:9:564
- Also: applied linter auto fixes