### PR TITLE
fix: fix error when accessing window.localStorage

### DIFF
--- a/misc/keyvaluestorage/src/browser/lib/localStorage.js
+++ b/misc/keyvaluestorage/src/browser/lib/localStorage.js
@@ -44,11 +44,16 @@
     return Object.keys(this).length;
   });
 
-  if (typeof global !== "undefined" && global.localStorage) {
-    module.exports = global.localStorage;
-  } else if (typeof window !== "undefined" && window.localStorage) {
-    module.exports = window.localStorage;
-  } else {
+  try {
+    if (typeof global !== "undefined" && global.localStorage) {
+      module.exports = global.localStorage;
+    } else if (typeof window !== "undefined" && window.localStorage) {
+      module.exports = window.localStorage;
+    } else {
+      module.exports = new LocalStorage();
+    }
+  } catch {
+    // In Incognito mode, accessing window.localStorage may thorw an error
     module.exports = new LocalStorage();
   }
 })();


### PR DESCRIPTION
Hello, we are using the wallet connect library successfully. However, we encountered an error during usage and have prepared a fix in the form of a pull request.

When using the wallet connect library in the iframe, accessing storage in incognito mode can be problematic. Specifically, reading `window.localStorage` within the iframe may throw an exception, especially when the "Block third-party cookies" option is turned on.

![image](https://github.com/WalletConnect/walletconnect-utils/assets/117259156/d81848cd-14f9-49fd-816a-b5b43d4b847d)
