### PR TITLE
fix(ws-connection): truncate query string on error log

### DIFF
--- a/jsonrpc/ws-connection/src/utils.ts
+++ b/jsonrpc/ws-connection/src/utils.ts
@@ -1,0 +1,14 @@
+export const resolveWebSocketImplementation = () => {
+  if (typeof global !== "undefined" && typeof global.WebSocket !== "undefined") {
+    return global.WebSocket;
+  }
+  if (typeof window !== "undefined" && typeof window.WebSocket !== "undefined") {
+    return window.WebSocket;
+  }
+
+  return require("ws");
+};
+
+export const isBrowser = () => typeof window !== "undefined";
+
+export const truncateQuery = (wssUrl: string) => wssUrl.split("?")[0];


### PR DESCRIPTION
## Context

### What

- Sets up `truncateQuery` util, applied when logging connection string
- Comparison for generic error logs:
	- Before: `WebSocket connection failed for URL: wss://relay.walletconnect.com?auth=...&projectId=...`
	- After: `WebSocket connection failed for host: wss://relay.walletconnect.com`
- Also:
	- Clean up helper fns into own `util` file

### Why

- This avoids unnecessarily detailed error logging, where the query params create unique errors in observability tooling, which are hard to dedupe.
- The query parameters do not provide useful debug info regarding misconfiguration, since we only log this error if the connection to the relay could not be made at all
- If the relay is reached, it returns a proper `3000` error code with a reason on the `close` event that can be used for debugging.

## Follow-ups

- [ ] Publish new patch version of `jsonrpc-ws-connection`
- [ ] Integrate downstream:
	- [ ] `jsonrpc-provider`
	- [ ] `@walletconnect/core`