### PR TITLE
fix(ws-connection): ensure builtin WebSockets are resolved exhaustively

### DIFF
--- a/jsonrpc/ws-connection/src/utils.ts
+++ b/jsonrpc/ws-connection/src/utils.ts
@@ -1,13 +1,22 @@
 export const resolveWebSocketImplementation = () => {
-  if (typeof global !== "undefined" && typeof global.WebSocket !== "undefined") {
+  if (typeof WebSocket !== "undefined") {
+    return WebSocket;
+  } else if (typeof global !== "undefined" && typeof global.WebSocket !== "undefined") {
     return global.WebSocket;
-  }
-  if (typeof window !== "undefined" && typeof window.WebSocket !== "undefined") {
+  } else if (typeof window !== "undefined" && typeof window.WebSocket !== "undefined") {
     return window.WebSocket;
+  } else if (typeof self !== "undefined" && typeof self.WebSocket !== "undefined") {
+    return self.WebSocket;
   }
 
   return require("ws");
 };
+
+export const hasBuiltInWebSocket = () =>
+  typeof WebSocket !== "undefined" ||
+  (typeof global !== "undefined" && typeof global.WebSocket !== "undefined") ||
+  (typeof window !== "undefined" && typeof window.WebSocket !== "undefined") ||
+  (typeof self !== "undefined" && typeof self.WebSocket !== "undefined");
 
 export const isBrowser = () => typeof window !== "undefined";
 

--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -9,7 +9,7 @@ import {
   isLocalhostUrl,
   parseConnectionError,
 } from "@walletconnect/jsonrpc-utils";
-import { truncateQuery, resolveWebSocketImplementation, isBrowser } from "./utils";
+import { truncateQuery, resolveWebSocketImplementation, hasBuiltInWebSocket } from "./utils";
 
 // Source: https://nodejs.org/api/events.html#emittersetmaxlistenersn
 const EVENT_EMITTER_MAX_LISTENERS_DEFAULT = 10;
@@ -119,7 +119,7 @@ export class WsConnection implements IJsonRpcConnection {
     return new Promise((resolve, reject) => {
       const opts = !isReactNative() ? { rejectUnauthorized: !isLocalhostUrl(url) } : undefined;
       const socket: WebSocket = new WS(url, [], opts);
-      if (isBrowser()) {
+      if (hasBuiltInWebSocket()) {
         socket.onerror = (event: Event) => {
           const errorEvent = event as ErrorEvent;
           reject(this.emitError(errorEvent.error));


### PR DESCRIPTION
## Context
- Fixes #116 
- Ensures all possible builtin `WebSocket` globals are exhaustively checked before defaulting to `ws` dep
- Ensures `socket.on` is only called for `ws`/non-builtin WebSocket implementations