### PR TITLE
Fix sending incorrect origin id

### DIFF
--- a/misc/history/src/types.ts
+++ b/misc/history/src/types.ts
@@ -7,7 +7,7 @@ export interface RegisterPayload {
 
 export interface GetMessagesPayload {
   topic: string;
-  originId?: number;
+  originId?: string;
   messageCount?: number;
   direction?: Direction;
 }


### PR DESCRIPTION
- `originId` number -> string per [spec](https://docs.walletconnect.com/2.0/specs/servers/history/history-server-api#example)