### PR TITLE
fix(identity-keys): ensure CACAO `domain` value is only the keyserver host

### DIFF
--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -74,7 +74,7 @@ export class IdentityKeys implements IIdentityKeys {
           },
           p: {
             aud: this.keyserverUrl,
-            statement: `${domain} wants you to sign in with your account: ${accountId}`,
+            statement: "",
             domain,
             iss: composeDidPkh(accountId),
             nonce: generateRandomBytes32(),

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -66,6 +66,7 @@ export class IdentityKeys implements IIdentityKeys {
       try {
         const [pubKeyHex, privKeyHex] = await this.generateIdentityKey();
         const didKey = encodeEd25519Key(pubKeyHex);
+        const domain = new URL(this.keyserverUrl).host;
 
         const cacao: Cacao = {
           h: {
@@ -73,8 +74,8 @@ export class IdentityKeys implements IIdentityKeys {
           },
           p: {
             aud: this.keyserverUrl,
-            statement: "Test",
-            domain: new URL(this.keyserverUrl).host,
+            statement: `${domain} wants you to sign in with your account: ${accountId}`,
+            domain,
             iss: composeDidPkh(accountId),
             nonce: generateRandomBytes32(),
             iat: new Date().toISOString(),

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -74,7 +74,7 @@ export class IdentityKeys implements IIdentityKeys {
           p: {
             aud: this.keyserverUrl,
             statement: "Test",
-            domain: this.keyserverUrl,
+            domain: new URL(this.keyserverUrl).host,
             iss: composeDidPkh(accountId),
             nonce: generateRandomBytes32(),
             iat: new Date().toISOString(),


### PR DESCRIPTION
Resolves #128 