### PR TITLE
fix: delete identity key after unregistering

### DIFF
--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -157,7 +157,7 @@ export class IdentityKeys implements IIdentityKeys {
         throw new Error(`Failed to unregister on keyserver ${response.status}`);
       }
 
-      await this.identityKeys.delete(account, { code: -1, message: "Account unregistered" })
+      await this.identityKeys.delete(account, { code: -1, message: "Account unregistered" });
     } catch (error) {
       this.core.logger.error(error);
       throw error;

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -157,7 +157,7 @@ export class IdentityKeys implements IIdentityKeys {
         throw new Error(`Failed to unregister on keyserver ${response.status}`);
       }
 
-      await this.identityKeys.delete(account, { code: -1, message: "Account unregistered" });
+      await this.identityKeys.delete(account, { code: -1, message: `Account ${account} unregistered` });
     } catch (error) {
       this.core.logger.error(error);
       throw error;

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -156,6 +156,8 @@ export class IdentityKeys implements IIdentityKeys {
       if (response.status !== 200) {
         throw new Error(`Failed to unregister on keyserver ${response.status}`);
       }
+
+      await this.identityKeys.delete(account, { code: -1, message: "Account unregistered" })
     } catch (error) {
       this.core.logger.error(error);
       throw error;


### PR DESCRIPTION
# Changes

- `unregisterIdentity` wasn't actually deleting the identity key after successful un-registration, now it does. 
This caused a bug in https://github.com/WalletConnect/notify-client-js/pull/60