### PR TITLE
feat: set origin header in react native

### DIFF
--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -117,7 +117,10 @@ export class WsConnection implements IJsonRpcConnection {
     this.registering = true;
 
     return new Promise((resolve, reject) => {
-      const opts = !isReactNative() ? { rejectUnauthorized: !isLocalhostUrl(url) } : undefined;
+      const origin = new URLSearchParams(url).get("origin");
+      const opts = isReactNative()
+        ? { headers: { origin } }
+        : { rejectUnauthorized: !isLocalhostUrl(url) };
       const socket: WebSocket = new WS(url, [], opts);
       if (hasBuiltInWebSocket()) {
         socket.onerror = (event: Event) => {


### PR DESCRIPTION
### Summary
Overriding the origin header in the relay connection for RN.

Tested:
- [x] using a project id with empty allowed domains
- [x] using a project id with specified allowed domains

Relates to: https://github.com/WalletConnect/walletconnect-monorepo/pull/3847