### PR TITLE
Refactor/identity keys persistence and signing

### DIFF
--- a/misc/identity-keys/CHANGELOG.md
+++ b/misc/identity-keys/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 ### Major Changes
 
-- Refactor registration to be multi function
+- Refactor registration to be multi function, with the following flow:
+  - `prepareRegistration`, 
+  - sign `message` independently, 
+  - then pass that `signature` along with `registerParams` from `prepareRegistration` into register.
 
-  Removes `onSign` function, instead passing signature to the second part of a duo function operation.
+- Removes `onSign` function, instead passing signature to the second part of a duo function operation.
 
 ## 0.2.3
 

--- a/misc/identity-keys/CHANGELOG.md
+++ b/misc/identity-keys/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @walletconnect/identity-keys
 
+## 1.0.0
+
+### Major Changes
+
+- Refactor registration to be multi function
+
+  Removes `onSign` function, instead passing signature to the second part of a duo function operation.
+
 ## 0.2.3
 
 ### Patch Changes

--- a/misc/identity-keys/CHANGELOG.md
+++ b/misc/identity-keys/CHANGELOG.md
@@ -1,12 +1,19 @@
 # @walletconnect/identity-keys
 
+## 1.0.1
+
+### Patch Changes
+
+- Replace viem with @ethersproject/transactions and @ethersproject/hash to optimize for size
+
 ## 1.0.0
 
 ### Major Changes
 
 - Refactor registration to be multi function, with the following flow:
-  - `prepareRegistration`, 
-  - sign `message` independently, 
+
+  - `prepareRegistration`,
+  - sign `message` independently,
   - then pass that `signature` along with `registerParams` from `prepareRegistration` into register.
 
 - Removes `onSign` function, instead passing signature to the second part of a duo function operation.

--- a/misc/identity-keys/package-lock.json
+++ b/misc/identity-keys/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@walletconnect/identity-keys",
-      "version": "0.2.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "webpack-cli": "^5.0.1"

--- a/misc/identity-keys/package-lock.json
+++ b/misc/identity-keys/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "1.0.0",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@walletconnect/identity-keys",
-      "version": "1.0.0",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "webpack-cli": "^5.0.1"

--- a/misc/identity-keys/package.json
+++ b/misc/identity-keys/package.json
@@ -51,13 +51,14 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
+    "@ethersproject/hash": "^5.7.0",
+    "@ethersproject/transactions": "^5.7.0",
     "@noble/ed25519": "^1.7.1",
     "@walletconnect/cacao": "1.0.2",
     "@walletconnect/core": "^2.10.1",
     "@walletconnect/did-jwt": "2.0.3",
     "@walletconnect/types": "^2.10.1",
     "@walletconnect/utils": "^2.10.1",
-    "axios": "^1.3.5",
-    "viem": "^1.19.11"
+    "axios": "^1.3.5"
   }
 }

--- a/misc/identity-keys/package.json
+++ b/misc/identity-keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "0.2.3",
+  "version": "1.0.0",
   "description": "Utilities to register, resolve and unregister identity keys",
   "keywords": [
     "identity",

--- a/misc/identity-keys/package.json
+++ b/misc/identity-keys/package.json
@@ -57,6 +57,7 @@
     "@walletconnect/did-jwt": "2.0.3",
     "@walletconnect/types": "^2.10.1",
     "@walletconnect/utils": "^2.10.1",
-    "axios": "^1.3.5"
+    "axios": "^1.3.5",
+    "viem": "^1.19.11"
   }
 }

--- a/misc/identity-keys/package.json
+++ b/misc/identity-keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Utilities to register, resolve and unregister identity keys",
   "keywords": [
     "identity",

--- a/misc/identity-keys/package.json
+++ b/misc/identity-keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "1.0.0",
+  "version": "0.2.3",
   "description": "Utilities to register, resolve and unregister identity keys",
   "keywords": [
     "identity",

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -1,5 +1,5 @@
 import * as ed25519 from "@noble/ed25519";
-import { verifyMessage } from "viem";
+import { verifyMessage } from "viem/utils";
 import { Cacao } from "@walletconnect/cacao";
 import { Store } from "@walletconnect/core";
 import {

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -101,8 +101,6 @@ export class IdentityKeys implements IIdentityKeys {
           throw new Error(`Provided an invalid signature. Expected a string but got: ${signature}`);
         }
 
-        console.log("Registering with signature", signature);
-
         const signatureValid = await verifyMessage({
           address: accountId.split(":").pop() as `0x${string}`,
           message,

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -1,5 +1,4 @@
 import * as ed25519 from "@noble/ed25519";
-import { verifyMessage } from "viem/utils";
 import { Cacao } from "@walletconnect/cacao";
 import { Store } from "@walletconnect/core";
 import {
@@ -9,6 +8,8 @@ import {
   generateJWT,
   jwtExp,
 } from "@walletconnect/did-jwt";
+import { hashMessage } from '@ethersproject/hash'
+import { recoverAddress } from '@ethersproject/transactions'
 import { ICore, IStore } from "@walletconnect/types";
 import { formatMessage, generateRandomBytes32 } from "@walletconnect/utils";
 import axios from "axios";
@@ -101,11 +102,8 @@ export class IdentityKeys implements IIdentityKeys {
           throw new Error(`Provided an invalid signature. Expected a string but got: ${signature}`);
         }
 
-        const signatureValid = await verifyMessage({
-          address: accountId.split(":").pop() as `0x${string}`,
-          message,
-          signature: signature as `0x${string}`,
-        });
+	const recoveredAddress = recoverAddress(hashMessage(message), signature);
+	const signatureValid = recoveredAddress.toLowerCase() === accountId.split(':').pop()!.toLowerCase();
 
         if (!signatureValid) {
           throw new Error(`Provided an invalid signature. Signature ${signature} by account

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -8,8 +8,8 @@ import {
   generateJWT,
   jwtExp,
 } from "@walletconnect/did-jwt";
-import { hashMessage } from '@ethersproject/hash'
-import { recoverAddress } from '@ethersproject/transactions'
+import { hashMessage } from "@ethersproject/hash";
+import { recoverAddress } from "@ethersproject/transactions";
 import { ICore, IStore } from "@walletconnect/types";
 import { formatMessage, generateRandomBytes32 } from "@walletconnect/utils";
 import axios from "axios";
@@ -102,8 +102,9 @@ export class IdentityKeys implements IIdentityKeys {
           throw new Error(`Provided an invalid signature. Expected a string but got: ${signature}`);
         }
 
-	const recoveredAddress = recoverAddress(hashMessage(message), signature);
-	const signatureValid = recoveredAddress.toLowerCase() === accountId.split(':').pop()!.toLowerCase();
+        const recoveredAddress = recoverAddress(hashMessage(message), signature);
+        const signatureValid =
+          recoveredAddress.toLowerCase() === accountId.split(":").pop()!.toLowerCase();
 
         if (!signatureValid) {
           throw new Error(`Provided an invalid signature. Signature ${signature} by account

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -63,11 +63,10 @@ export class IdentityKeys implements IIdentityKeys {
 
     const cacaoPayload = {
       aud: encodeEd25519Key(pubKeyHex),
-      iss: composeDidPkh(accountId),
       statement,
       domain,
+      iss: composeDidPkh(accountId),
       nonce: generateRandomBytes32(),
-
       iat: new Date().toISOString(),
       version: "1",
       resources: [
@@ -129,10 +128,8 @@ export class IdentityKeys implements IIdentityKeys {
           },
 	}
 
-	console.log(cacao)
-
         try {
-          await axios.post(url, cacao);
+          await axios.post(url, { cacao });
         } catch (e) {
 	  
           throw new Error(`Failed to register on keyserver: ${e}`);

--- a/misc/identity-keys/src/types.ts
+++ b/misc/identity-keys/src/types.ts
@@ -2,7 +2,10 @@ import { CacaoPayload, Cacao } from "@walletconnect/cacao";
 import { JwtPayload } from "@walletconnect/did-jwt";
 
 export interface RegisterIdentityParams {
-  cacaoPayload: CacaoPayload
+  registerParams: {
+    cacaoPayload: CacaoPayload,
+    privateIdentityKey: Uint8Array
+  }
   signature: string
 }
 

--- a/misc/identity-keys/src/types.ts
+++ b/misc/identity-keys/src/types.ts
@@ -1,11 +1,9 @@
-import { Cacao } from "@walletconnect/cacao";
+import { CacaoPayload, Cacao } from "@walletconnect/cacao";
 import { JwtPayload } from "@walletconnect/did-jwt";
 
 export interface RegisterIdentityParams {
-  accountId: string;
-  onSign: (message: string) => Promise<string | undefined>;
-  domain: string;
-  statement: string;
+  cacaoPayload: CacaoPayload
+  signature: string
 }
 
 export interface ResolveIdentityParams {

--- a/misc/identity-keys/src/types.ts
+++ b/misc/identity-keys/src/types.ts
@@ -3,10 +3,10 @@ import { JwtPayload } from "@walletconnect/did-jwt";
 
 export interface RegisterIdentityParams {
   registerParams: {
-    cacaoPayload: CacaoPayload,
-    privateIdentityKey: Uint8Array
-  }
-  signature: string
+    cacaoPayload: CacaoPayload;
+    privateIdentityKey: Uint8Array;
+  };
+  signature: string;
 }
 
 export interface ResolveIdentityParams {

--- a/misc/identity-keys/test/identity-keys.test.ts
+++ b/misc/identity-keys/test/identity-keys.test.ts
@@ -63,15 +63,17 @@ describe("@walletconnect/identity-keys", () => {
     // rejectedWith & rejected are not supported on this version of chai
     let failMessage = "";
     
+    const signature = await wallet.signMessage("otherMessage");
     await identityKeys
       .registerIdentity({
 	registerParams,
-	signature: "badSignature",
+	signature,
       })
       .catch((err) => (failMessage = err.message));
 
-    expect(failMessage).eq(
-      `Failed to register on keyserver: AxiosError: Request failed with status code 400`,
+    expect(failMessage).match(
+      new RegExp(`Provided an invalid signature. Signature ${signature} by account
+            ${accountId} is not a valid signature for message .*`),
     );
 
     const keys = identityKeys.identityKeys.getAll();

--- a/misc/identity-keys/test/identity-keys.test.ts
+++ b/misc/identity-keys/test/identity-keys.test.ts
@@ -33,14 +33,14 @@ describe("@walletconnect/identity-keys", () => {
     const { message, registerParams } = await identityKeys.prepareRegistration({
       accountId,
       statement,
-      domain
-    })
+      domain,
+    });
 
     const signature = await wallet.signMessage(message);
 
     const identity = await identityKeys.registerIdentity({
       registerParams,
-      signature 
+      signature,
     });
 
     const encodedIdentity = encodeEd25519Key(identity).split(":")[2];
@@ -53,21 +53,20 @@ describe("@walletconnect/identity-keys", () => {
   });
 
   it("does not persist identity keys that failed to register", async () => {
-
     const { registerParams } = await identityKeys.prepareRegistration({
       accountId,
       statement,
-      domain
-    })
+      domain,
+    });
 
     // rejectedWith & rejected are not supported on this version of chai
     let failMessage = "";
-    
+
     const signature = await wallet.signMessage("otherMessage");
     await identityKeys
       .registerIdentity({
-	registerParams,
-	signature,
+        registerParams,
+        signature,
       })
       .catch((err) => (failMessage = err.message));
 
@@ -81,19 +80,18 @@ describe("@walletconnect/identity-keys", () => {
   });
 
   it("prevents registering with empty signatures", async () => {
-
     const { registerParams } = await identityKeys.prepareRegistration({
       accountId,
       statement,
-      domain
+      domain,
     });
 
     // rejectedWith & rejected are not supported on this version of chai
     let failMessage = "";
     await identityKeys
       .registerIdentity({
-	registerParams,
-	signature: ''
+        registerParams,
+        signature: "",
       })
       .catch((err) => (failMessage = err.message));
 

--- a/misc/identity-keys/tsconfig.json
+++ b/misc/identity-keys/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "./dist/types",
+    "ignoreDeprecations": "5.0",
     "emitDeclarationOnly": true
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,7 +483,7 @@
     },
     "misc/identity-keys": {
       "name": "@walletconnect/identity-keys",
-      "version": "1.0.0",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
@@ -29989,7 +29989,7 @@
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
         "axios": "^1.3.5",
-        "viem": "^1.19.11",
+        "viem": "*",
         "webpack-cli": "^5.0.1"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,17 +483,18 @@
     },
     "misc/identity-keys": {
       "name": "@walletconnect/identity-keys",
-      "version": "0.2.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",
         "@walletconnect/core": "^2.10.1",
         "@walletconnect/did-jwt": "2.0.3",
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
-        "axios": "^1.3.5",
-        "viem": "^1.19.11"
+        "axios": "^1.3.5"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
@@ -690,29 +691,6 @@
         }
       }
     },
-    "misc/identity-keys/node_modules/abitype": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
-      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.19.1"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "misc/identity-keys/node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -880,49 +858,6 @@
         }
       }
     },
-    "misc/identity-keys/node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "misc/identity-keys/node_modules/viem": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz",
-      "integrity": "sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@scure/bip32": "1.3.2",
-        "@scure/bip39": "1.2.1",
-        "abitype": "0.9.8",
-        "isows": "1.0.3",
-        "ws": "8.13.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "misc/identity-keys/node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -1053,26 +988,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "misc/identity-keys/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "misc/keyvaluestorage": {
@@ -1431,11 +1346,6 @@
         "webpack": "^4.41.6",
         "webpack-cli": "^3.3.11"
       }
-    },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -6042,17 +5952,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
@@ -6063,17 +5962,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7647,39 +7535,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
-    },
-    "node_modules/@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
-      "dependencies": {
-        "@noble/curves": "~1.2.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
-      "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -14949,20 +14804,6 @@
       "dependencies": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
-      }
-    },
-    "node_modules/isows": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "peerDependencies": {
-        "ws": "*"
       }
     },
     "node_modules/jest-diff": {
@@ -24769,11 +24610,6 @@
     }
   },
   "dependencies": {
-    "@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
-    },
     "@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -28003,23 +27839,10 @@
       "dev": true,
       "optional": true
     },
-    "@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "requires": {
-        "@noble/hashes": "1.3.2"
-      }
-    },
     "@noble/ed25519": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
       "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
-    },
-    "@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -29158,30 +28981,6 @@
         }
       }
     },
-    "@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q=="
-    },
-    "@scure/bip32": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
-      "requires": {
-        "@noble/curves": "~1.2.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.2"
-      }
-    },
-    "@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
-      "requires": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
-      }
-    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -29977,6 +29776,8 @@
     "@walletconnect/identity-keys": {
       "version": "file:misc/identity-keys",
       "requires": {
+        "@ethersproject/hash": "*",
+        "@ethersproject/transactions": "*",
         "@ethersproject/wallet": "^5.7.0",
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",
@@ -29989,7 +29790,6 @@
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
         "axios": "^1.3.5",
-        "viem": "*",
         "webpack-cli": "^5.0.1"
       },
       "dependencies": {
@@ -30156,12 +29956,6 @@
           "dev": true,
           "requires": {}
         },
-        "abitype": {
-          "version": "0.9.8",
-          "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
-          "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
-          "requires": {}
-        },
         "commander": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -30274,28 +30068,6 @@
             "terser": "^5.16.8"
           }
         },
-        "typescript": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-          "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
-          "optional": true,
-          "peer": true
-        },
-        "viem": {
-          "version": "1.19.11",
-          "resolved": "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz",
-          "integrity": "sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==",
-          "requires": {
-            "@adraffy/ens-normalize": "1.10.0",
-            "@noble/curves": "1.2.0",
-            "@noble/hashes": "1.3.2",
-            "@scure/bip32": "1.3.2",
-            "@scure/bip39": "1.2.1",
-            "abitype": "0.9.8",
-            "isows": "1.0.3",
-            "ws": "8.13.0"
-          }
-        },
         "watchpack": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -30376,12 +30148,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-          "requires": {}
         }
       }
     },
@@ -35927,12 +35693,6 @@
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
       }
-    },
-    "isows": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
-      "requires": {}
     },
     "jest-diff": {
       "version": "26.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,7 +483,7 @@
     },
     "misc/identity-keys": {
       "name": "@walletconnect/identity-keys",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
@@ -492,7 +492,8 @@
         "@walletconnect/did-jwt": "2.0.3",
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
-        "axios": "^1.3.5"
+        "axios": "^1.3.5",
+        "viem": "^1.19.11"
       },
       "devDependencies": {
         "@ethersproject/wallet": "^5.7.0",
@@ -689,6 +690,29 @@
         }
       }
     },
+    "misc/identity-keys/node_modules/abitype": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
+      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "misc/identity-keys/node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -856,6 +880,49 @@
         }
       }
     },
+    "misc/identity-keys/node_modules/typescript": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "misc/identity-keys/node_modules/viem": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz",
+      "integrity": "sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@scure/bip32": "1.3.2",
+        "@scure/bip39": "1.2.1",
+        "abitype": "0.9.8",
+        "isows": "1.0.3",
+        "ws": "8.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "misc/identity-keys/node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -986,6 +1053,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "misc/identity-keys/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "misc/keyvaluestorage": {
@@ -1344,6 +1431,11 @@
         "webpack": "^4.41.6",
         "webpack-cli": "^3.3.11"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -5950,6 +6042,17 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
@@ -5960,6 +6063,17 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7533,6 +7647,39 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
+      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "dependencies": {
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -14802,6 +14949,20 @@
       "dependencies": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
+      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/jest-diff": {
@@ -24608,6 +24769,11 @@
     }
   },
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
+    },
     "@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -27837,10 +28003,23 @@
       "dev": true,
       "optional": true
     },
+    "@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "requires": {
+        "@noble/hashes": "1.3.2"
+      }
+    },
     "@noble/ed25519": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
       "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ=="
+    },
+    "@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -28979,6 +29158,30 @@
         }
       }
     },
+    "@scure/base": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
+      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q=="
+    },
+    "@scure/bip32": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "requires": {
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.2"
+      }
+    },
+    "@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "requires": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -29786,6 +29989,7 @@
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
         "axios": "^1.3.5",
+        "viem": "*",
         "webpack-cli": "^5.0.1"
       },
       "dependencies": {
@@ -29952,6 +30156,12 @@
           "dev": true,
           "requires": {}
         },
+        "abitype": {
+          "version": "0.9.8",
+          "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
+          "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
+          "requires": {}
+        },
         "commander": {
           "version": "10.0.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -30064,6 +30274,28 @@
             "terser": "^5.16.8"
           }
         },
+        "typescript": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+          "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+          "optional": true,
+          "peer": true
+        },
+        "viem": {
+          "version": "1.19.11",
+          "resolved": "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz",
+          "integrity": "sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.10.0",
+            "@noble/curves": "1.2.0",
+            "@noble/hashes": "1.3.2",
+            "@scure/bip32": "1.3.2",
+            "@scure/bip39": "1.2.1",
+            "abitype": "0.9.8",
+            "isows": "1.0.3",
+            "ws": "8.13.0"
+          }
+        },
         "watchpack": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -30144,6 +30376,12 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        },
+        "ws": {
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "requires": {}
         }
       }
     },
@@ -35689,6 +35927,12 @@
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
       }
+    },
+    "isows": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
+      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
+      "requires": {}
     },
     "jest-diff": {
       "version": "26.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,7 +483,7 @@
     },
     "misc/identity-keys": {
       "name": "@walletconnect/identity-keys",
-      "version": "0.2.3",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
@@ -29989,7 +29989,7 @@
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
         "axios": "^1.3.5",
-        "viem": "*",
+        "viem": "^1.19.11",
         "webpack-cli": "^5.0.1"
       },
       "dependencies": {


### PR DESCRIPTION
# Changes
Refactor how identity keys signing:
- No longer receive `onSign`, instead split the registration function into two:
    - `prepareRegistration`: generate an identity keypair, format a cacao payload and a cacao message
    - `register`: actually perform the registration on the keyserver and persist the keys if successful, using externally provided signature
- Added `viem` for signature verification (`ignoreDeprecations: "5.0"` in tsconfig added to allow that)

# Context
For the notify SDK to comply with the new specs added [here](https://github.com/WalletConnect/walletconnect-specs/pull/177), splitting the registration function, this util needs to do the same.
