### PR TITLE
chore: add eip1271 support BREAKING CHANGE

### DIFF
--- a/misc/did-jwt/src/types.ts
+++ b/misc/did-jwt/src/types.ts
@@ -5,7 +5,7 @@ export interface JwtHeader {
 
 export interface JwtPayload {
   iss: string;
-  sub: string;
+  sub?: string;
   iat: number;
   exp: number;
   act: string;

--- a/misc/did-jwt/src/types.ts
+++ b/misc/did-jwt/src/types.ts
@@ -5,7 +5,7 @@ export interface JwtHeader {
 
 export interface JwtPayload {
   iss: string;
-  sub?: string;
+  sub: string;
   iat: number;
   exp: number;
   act: string;

--- a/misc/identity-keys/CHANGELOG.md
+++ b/misc/identity-keys/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @walletconnect/identity-keys
 
+## 2.0.1
+
+### Patch Changes
+
+- Fix bug where chainPrefix is not added for eip1271 calls
+
+## 2.0.0
+
+### Major Changes
+
+- Add support for eip1271 verification
+- Change API to accept type alongwith the signature
+
 ## 1.0.1
 
 ### Patch Changes

--- a/misc/identity-keys/package-lock.json
+++ b/misc/identity-keys/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "0.2.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@walletconnect/identity-keys",
-      "version": "0.2.2",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "webpack-cli": "^5.0.1"

--- a/misc/identity-keys/package.json
+++ b/misc/identity-keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Utilities to register, resolve and unregister identity keys",
   "keywords": [
     "identity",

--- a/misc/identity-keys/package.json
+++ b/misc/identity-keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/identity-keys",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Utilities to register, resolve and unregister identity keys",
   "keywords": [
     "identity",

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -97,28 +97,32 @@ export class IdentityKeys implements IIdentityKeys {
         const message = formatMessage(registerParams.cacaoPayload, registerParams.cacaoPayload.iss);
 
         if (!signature.s) {
-          throw new Error(`Provided an invalid signature. Expected a string but got: ${signature.s}`);
+          throw new Error(
+            `Provided an invalid signature. Expected a string but got: ${signature.s}`,
+          );
         }
 
         const [, chain, address] = accountId.split(":");
-	const invalidSignatureError =
-	  `Provided an invalid signature. Signature ${signature.s} of type ${signature.t} by account ${accountId} is not a valid signature for message ${message}`
+        const invalidSignatureError = `Provided an invalid signature. Signature ${signature.s} of type ${signature.t} by account ${accountId} is not a valid signature for message ${message}`;
 
-	let signatureValid = false;
+        let signatureValid = false;
 
-	// account for an invalid signature
-	try {
-	  signatureValid = await verifySignature(address, message, signature, chain, this.projectId);
-	}
-	catch {
-	  signatureValid = false;
-	}
+        // account for an invalid signature
+        try {
+          signatureValid = await verifySignature(
+            address,
+            message,
+            signature,
+            chain,
+            this.projectId,
+          );
+        } catch {
+          signatureValid = false;
+        }
 
         if (!signatureValid) {
           throw new Error(invalidSignatureError);
         }
-
-
 
         const url = `${this.keyserverUrl}/identity`;
 

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -100,14 +100,8 @@ export class IdentityKeys implements IIdentityKeys {
           throw new Error(`Provided an invalid signature. Expected a string but got: ${signature}`);
         }
 
-	const [,chain,address] = accountId.split(':');
-        const signatureValid = verifySignature(
-	  address,
-	  message,
-	  signature,
-	  chain,
-	  this.projectId
-	);
+        const [, chain, address] = accountId.split(":");
+        const signatureValid = verifySignature(address, message, signature, chain, this.projectId);
 
         if (!signatureValid) {
           throw new Error(`Provided an invalid signature. Signature ${signature} by account

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -102,7 +102,7 @@ export class IdentityKeys implements IIdentityKeys {
           );
         }
 
-        const [, chain, address] = accountId.split(":");
+        const [chainPrefix, chain, address] = accountId.split(":");
         const invalidSignatureError = `Provided an invalid signature. Signature ${signature.s} of type ${signature.t} by account ${accountId} is not a valid signature for message ${message}`;
 
         let signatureValid = false;
@@ -113,7 +113,7 @@ export class IdentityKeys implements IIdentityKeys {
             address,
             message,
             signature,
-            chain,
+            `${chainPrefix}:${chain}`,
             this.projectId,
           );
         } catch {

--- a/misc/identity-keys/src/identity-keys.ts
+++ b/misc/identity-keys/src/identity-keys.ts
@@ -102,7 +102,7 @@ export class IdentityKeys implements IIdentityKeys {
 
         const [, chain, address] = accountId.split(":");
 	const invalidSignatureError =
-	  `Provided an invalid signature. Signature ${signature.s} by account ${accountId} is not a valid signature for message ${message}`
+	  `Provided an invalid signature. Signature ${signature.s} of type ${signature.t} by account ${accountId} is not a valid signature for message ${message}`
 
 	let signatureValid = false;
 

--- a/misc/identity-keys/src/types.ts
+++ b/misc/identity-keys/src/types.ts
@@ -1,4 +1,4 @@
-import { CacaoPayload, Cacao } from "@walletconnect/cacao";
+import { CacaoPayload, Cacao, CacaoSignature } from "@walletconnect/cacao";
 import { JwtPayload } from "@walletconnect/did-jwt";
 
 export interface RegisterIdentityParams {
@@ -6,7 +6,7 @@ export interface RegisterIdentityParams {
     cacaoPayload: CacaoPayload;
     privateIdentityKey: Uint8Array;
   };
-  signature: string;
+  signature: CacaoSignature;
 }
 
 export interface ResolveIdentityParams {

--- a/misc/identity-keys/test/identity-keys.test.ts
+++ b/misc/identity-keys/test/identity-keys.test.ts
@@ -76,10 +76,8 @@ describe("@walletconnect/identity-keys", () => {
       })
       .catch((err) => (failMessage = err.message));
 
-    console.log({failMessage})
-
     expect(failMessage).match(
-      new RegExp(`Provided an invalid signature. Signature ${signature} by account ${accountId} is not a valid signature for message.*`),
+      new RegExp(`Provided an invalid signature. Signature ${signature} of type eip191 by account ${accountId} is not a valid signature for message.*`),
     );
 
     const keys = identityKeys.identityKeys.getAll();

--- a/misc/identity-keys/test/identity-keys.test.ts
+++ b/misc/identity-keys/test/identity-keys.test.ts
@@ -40,7 +40,10 @@ describe("@walletconnect/identity-keys", () => {
 
     const identity = await identityKeys.registerIdentity({
       registerParams,
-      signature,
+      signature: {
+	s: signature,
+	t: 'eip191'
+      },
     });
 
     const encodedIdentity = encodeEd25519Key(identity).split(":")[2];
@@ -66,7 +69,10 @@ describe("@walletconnect/identity-keys", () => {
     await identityKeys
       .registerIdentity({
         registerParams,
-        signature,
+        signature: {
+          s: signature,
+          t: 'eip191'
+        },
       })
       .catch((err) => (failMessage = err.message));
 
@@ -91,7 +97,10 @@ describe("@walletconnect/identity-keys", () => {
     await identityKeys
       .registerIdentity({
         registerParams,
-        signature: "",
+        signature: {
+          s: "",
+          t: 'eip191'
+        },
       })
       .catch((err) => (failMessage = err.message));
 

--- a/misc/identity-keys/test/identity-keys.test.ts
+++ b/misc/identity-keys/test/identity-keys.test.ts
@@ -77,7 +77,9 @@ describe("@walletconnect/identity-keys", () => {
       .catch((err) => (failMessage = err.message));
 
     expect(failMessage).match(
-      new RegExp(`Provided an invalid signature. Signature ${signature} of type eip191 by account ${accountId} is not a valid signature for message.*`),
+      new RegExp(
+        `Provided an invalid signature. Signature ${signature} of type eip191 by account ${accountId} is not a valid signature for message.*`,
+      ),
     );
 
     const keys = identityKeys.identityKeys.getAll();

--- a/misc/identity-keys/test/identity-keys.test.ts
+++ b/misc/identity-keys/test/identity-keys.test.ts
@@ -76,9 +76,10 @@ describe("@walletconnect/identity-keys", () => {
       })
       .catch((err) => (failMessage = err.message));
 
+    console.log({failMessage})
+
     expect(failMessage).match(
-      new RegExp(`Provided an invalid signature. Signature ${signature} by account
-            ${accountId} is not a valid signature for message .*`),
+      new RegExp(`Provided an invalid signature. Signature ${signature} by account ${accountId} is not a valid signature for message.*`),
     );
 
     const keys = identityKeys.identityKeys.getAll();

--- a/misc/identity-keys/test/identity-keys.test.ts
+++ b/misc/identity-keys/test/identity-keys.test.ts
@@ -41,8 +41,8 @@ describe("@walletconnect/identity-keys", () => {
     const identity = await identityKeys.registerIdentity({
       registerParams,
       signature: {
-	s: signature,
-	t: 'eip191'
+        s: signature,
+        t: "eip191",
       },
     });
 
@@ -71,7 +71,7 @@ describe("@walletconnect/identity-keys", () => {
         registerParams,
         signature: {
           s: signature,
-          t: 'eip191'
+          t: "eip191",
         },
       })
       .catch((err) => (failMessage = err.message));
@@ -99,7 +99,7 @@ describe("@walletconnect/identity-keys", () => {
         registerParams,
         signature: {
           s: "",
-          t: 'eip191'
+          t: "eip191",
         },
       })
       .catch((err) => (failMessage = err.message));

--- a/package-lock.json
+++ b/package-lock.json
@@ -483,7 +483,7 @@
     },
     "misc/identity-keys": {
       "name": "@walletconnect/identity-keys",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/hash": "^5.7.0",
@@ -29776,8 +29776,8 @@
     "@walletconnect/identity-keys": {
       "version": "file:misc/identity-keys",
       "requires": {
-        "@ethersproject/hash": "*",
-        "@ethersproject/transactions": "*",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",


### PR DESCRIPTION
- add `eip1271` support via `@walletconnect/cacao`
- Introduce **BREAKING CHANGE** where `signature` is no longer a `string` but instead a `CacaoSignature`
- Modify error message to showcase type of signature
- This is all in service of supporting eip1271 in notify client and thus Web3Inbox
- Bump major version to `2.0.0` since this is a breaking change