### PR TITLE
chore: bump version

### DIFF
--- a/misc/logger/CHANGELOG.md
+++ b/misc/logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @walletconnect/logger
 
+## 2.1.1
+
+### Patch Changes
+
+- Update naming for logger file download
+
 ## 2.1.0
 
 ### Minor Changes

--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/logger",
   "description": "Logger Utils",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "homepage": "https://github.com/WalletConnect/walletconnect-utils/",


### PR DESCRIPTION
Bump patch version for logger following https://github.com/WalletConnect/walletconnect-utils/commit/0678a57e8ae500e5b982feab18116e6e6b8b3385