### PR TITLE
chore: do not extend writable, use destinationstream from pino

### DIFF
--- a/misc/logger/CHANGELOG.md
+++ b/misc/logger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @walletconnect/logger
 
+## 2.1.2
+
+### Patch Changes
+
+- Fix build bug caused by depending on stream
+
 ## 2.1.1
 
 ### Patch Changes

--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/logger",
   "description": "Logger Utils",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "homepage": "https://github.com/WalletConnect/walletconnect-utils/",

--- a/misc/logger/src/serverChunkLogger.ts
+++ b/misc/logger/src/serverChunkLogger.ts
@@ -1,27 +1,19 @@
 import { MAX_LOG_SIZE_IN_BYTES_DEFAULT } from "./constants";
-import { Writable } from "stream";
-import type { LoggerOptions } from "pino";
+import type { DestinationStream, LoggerOptions } from "pino";
 import BaseChunkLogger from "./baseChunkLogger";
 
-export default class ServerChunkLogger extends Writable {
+export default class ServerChunkLogger implements DestinationStream {
   private baseChunkLogger: BaseChunkLogger;
 
   public constructor(
     level: LoggerOptions["level"],
     MAX_LOG_SIZE_IN_BYTES: number = MAX_LOG_SIZE_IN_BYTES_DEFAULT,
   ) {
-    super({ objectMode: true });
-
     this.baseChunkLogger = new BaseChunkLogger(level, MAX_LOG_SIZE_IN_BYTES);
   }
 
-  public _write(chunk: any, _encoding: string, callback: (error?: Error | null) => void): void {
-    try {
-      this.baseChunkLogger.appendToLogs(chunk);
-      callback();
-    } catch (error: any) {
-      callback(error);
-    }
+  public write(chunk: any): void {
+    this.baseChunkLogger.appendToLogs(chunk);
   }
 
   public getLogs() {


### PR DESCRIPTION
> [!NOTE]
> Canary of this fix already published at: `@walletconnect/logger@2.1.2-98c4166`


- Resolves #166 
- Resolves https://github.com/WalletConnect/walletconnect-monorepo/issues/4414

# How was this reproduced 
- Clone a repro case here: https://github.com/WalletConnect/walletconnect-monorepo/issues/4414:
    - Clone repo
    - Upgrade to web3wallet `1.11.1` 
    - Observe build failure

# How was this fixed
- Remove both references to `Writable`
- Maintain current API by instead satisfying Pino's `DestinationStream` interface

# How was this tested
## Ensure it resolves issue
- Go back to repro case mentioned above
- Perform the following:
- First, add the following section to the package.sjon:
```json
	"resolutions": {
		"@walletconnect/logger": "2.1.2-98c4166"
	},
```
- Then use `npm-force-resolutions` to force `@walletconnect/logger`'s canary to be fetched instead of the current latest
- Observe build pipeline succeeds
## Ensure test pipeline passes
The current tests already use the `ServerChunkLogger` so them passing indicates that behaviour is effectively unchanged