### PR TITLE
Improve payloadId generator

### DIFF
--- a/jsonrpc/utils/src/format.ts
+++ b/jsonrpc/utils/src/format.ts
@@ -21,8 +21,7 @@ const uint8Generator = new IncrementalRandomGenerator(8);
 const uint32Generator = new IncrementalRandomGenerator(32);
 
 export function payloadId(): number {
-  const now = Date.now();
-  const date = now * 1000;
+  const date = Date.now() * 1000;
   const extra = uint8Generator.getNextValue();
   return date + extra;
 }

--- a/jsonrpc/utils/src/format.ts
+++ b/jsonrpc/utils/src/format.ts
@@ -2,9 +2,37 @@ import { getError, getErrorByCode, isReservedErrorCode } from "./error";
 import { INTERNAL_ERROR, SERVER_ERROR } from "./constants";
 import { ErrorResponse, JsonRpcError, JsonRpcRequest, JsonRpcResult } from "./types";
 
+class IncrementalRandomGenerator {
+  private typedArray: Uint8Array | Uint16Array | Uint32Array;
+  private shift: number;
+  private base = 1;
+
+  static getBitsOf(typedArray: Uint8Array | Uint16Array | Uint32Array) {
+    if (!typedArray.length) {
+      throw new Error("Empty typed array");
+    }
+    return (typedArray.byteLength / typedArray.length) * 8;
+  }
+
+  constructor(bits: 8 | 16 | 32) {
+    this.typedArray =
+      bits === 8 ? new Uint8Array(1) : bits === 16 ? new Uint16Array(1) : new Uint32Array(1);
+    this.shift = IncrementalRandomGenerator.getBitsOf(this.typedArray);
+  }
+
+  getRandomValue() {
+    return (this.base++ << this.shift) + crypto.getRandomValues(this.typedArray)[0];
+  }
+}
+
+const uint8Generator = new IncrementalRandomGenerator(8);
+const uint16Generator = new IncrementalRandomGenerator(16);
+
 export function payloadId(entropy = 3): number {
-  const date = Date.now() * Math.pow(10, entropy);
-  const extra = Math.floor(Math.random() * Math.pow(10, entropy));
+  const generator = entropy > 3 ? uint16Generator : uint8Generator;
+  const shift = entropy > 3 ? 10000 : 1000000;
+  const date = Date.now() * Math.pow(10, shift);
+  const extra = generator.getRandomValue();
   return date + extra;
 }
 

--- a/jsonrpc/utils/src/format.ts
+++ b/jsonrpc/utils/src/format.ts
@@ -18,7 +18,7 @@ class IncrementalRandomGenerator {
 }
 
 const uint8Generator = new IncrementalRandomGenerator(8);
-const uint32Generator = new IncrementalRandomGenerator(32);
+const uint16Generator = new IncrementalRandomGenerator(16);
 
 export function payloadId(): number {
   const date = Date.now() * 1000;
@@ -27,8 +27,8 @@ export function payloadId(): number {
 }
 
 export function getBigIntRpcId(): bigint {
-  const date = BigInt(Date.now()) * BigInt(10000000000);
-  const extra = BigInt(uint32Generator.getNextValue());
+  const date = BigInt(Date.now()) * BigInt(1000000);
+  const extra = BigInt(uint16Generator.getNextValue());
   return date + extra;
 }
 

--- a/jsonrpc/utils/test/payloadId.test.ts
+++ b/jsonrpc/utils/test/payloadId.test.ts
@@ -25,10 +25,6 @@ describe("Payload Id", () => {
     chai.expect(payloadId().toString().length).to.equal(16);
   });
 
-  it("returns a bigint with 19 digits", () => {
-    chai.expect(getBigIntRpcId().toString().length).to.equal(19);
-  });
-
   // Context: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
   it("returns a safe integer", () => {
     chai.expect(Number.isSafeInteger(payloadId())).to.be.true;
@@ -45,5 +41,72 @@ describe("Payload Id", () => {
     );
     const duplicates = findDuplicates(results);
     chai.expect(duplicates.length === 0).to.be.true;
+  });
+
+  it("generates increasing values when called within same tick", () => {
+    let i = 0;
+    while (i++ < 10000) {
+      const value1 = payloadId();
+      const value2 = payloadId();
+      const value3 = payloadId();
+      const value4 = payloadId();
+      if (value1 >= value2 || value2 >= value3 || value3 >= value4) {
+        chai.assert.fail("Not increasing values");
+      }
+    }
+    chai.assert.isOk("Pass");
+  });
+
+  it("generates non-repeating values when called within same tick", () => {
+    let i = 0;
+    while (i++ < 10000) {
+      const value1 = payloadId();
+      const value2 = payloadId();
+      const value3 = payloadId();
+      const value4 = payloadId();
+      if (value1 === value2 || value2 === value3 || value3 === value4) {
+        chai.assert.fail("Not unique values");
+      }
+    }
+    chai.assert.isOk("Pass");
+  });
+});
+
+describe("Get BigInt Rpc Id", () => {
+  it("returns a bigint", () => {
+    const value = getBigIntRpcId();
+    chai.expect(typeof value === "bigint").to.be.true;
+  });
+
+  it("returns a bigint with 23 digits", () => {
+    chai.expect(getBigIntRpcId().toString().length).to.equal(23);
+  });
+
+  it("generates increasing values when called within same tick", () => {
+    let i = 0;
+    while (i++ < 10000) {
+      const value1 = getBigIntRpcId();
+      const value2 = getBigIntRpcId();
+      const value3 = getBigIntRpcId();
+      const value4 = getBigIntRpcId();
+      if (value1 >= value2 || value2 >= value3 || value3 >= value4) {
+        chai.assert.fail("Not increasing values");
+      }
+    }
+    chai.assert.isOk("Pass");
+  });
+
+  it("generates non-repeating values when called within same tick", () => {
+    let i = 0;
+    while (i++ < 10000) {
+      const value1 = getBigIntRpcId();
+      const value2 = getBigIntRpcId();
+      const value3 = getBigIntRpcId();
+      const value4 = getBigIntRpcId();
+      if (value1 === value2 || value2 === value3 || value3 === value4) {
+        chai.assert.fail("Not unique values");
+      }
+    }
+    chai.assert.isOk("Pass");
   });
 });

--- a/jsonrpc/utils/test/payloadId.test.ts
+++ b/jsonrpc/utils/test/payloadId.test.ts
@@ -60,11 +60,9 @@ describe("Payload Id", () => {
   it("generates non-repeating values when called within same tick", () => {
     let i = 0;
     while (i++ < 10000) {
-      const value1 = payloadId();
-      const value2 = payloadId();
-      const value3 = payloadId();
-      const value4 = payloadId();
-      if (value1 === value2 || value2 === value3 || value3 === value4) {
+      const values = [payloadId(), payloadId(), payloadId(), payloadId()];
+      const set = new Set(values);
+      if (set.size !== values.length) {
         chai.assert.fail("Not unique values");
       }
     }
@@ -99,11 +97,9 @@ describe("Get BigInt Rpc Id", () => {
   it("generates non-repeating values when called within same tick", () => {
     let i = 0;
     while (i++ < 10000) {
-      const value1 = getBigIntRpcId();
-      const value2 = getBigIntRpcId();
-      const value3 = getBigIntRpcId();
-      const value4 = getBigIntRpcId();
-      if (value1 === value2 || value2 === value3 || value3 === value4) {
+      const values = [getBigIntRpcId(), getBigIntRpcId(), getBigIntRpcId(), getBigIntRpcId()];
+      const set = new Set(values);
+      if (set.size !== values.length) {
         chai.assert.fail("Not unique values");
       }
     }

--- a/jsonrpc/utils/test/payloadId.test.ts
+++ b/jsonrpc/utils/test/payloadId.test.ts
@@ -76,8 +76,8 @@ describe("Get BigInt Rpc Id", () => {
     chai.expect(typeof value === "bigint").to.be.true;
   });
 
-  it("returns a bigint with 23 digits", () => {
-    chai.expect(getBigIntRpcId().toString().length).to.equal(23);
+  it("returns a bigint with 19 digits", () => {
+    chai.expect(getBigIntRpcId().toString().length).to.equal(19);
   });
 
   it("generates increasing values when called within same tick", () => {


### PR DESCRIPTION
**Problem**

Current `payloadId` function has defects:
* It doesn't guarantee to return a unique value (due to Math.random() not being suited for cryptography and due to single-threadedness of javascript)
* It doesn't guarantee to always return a value greater than the previous one (since `Date.now()` can return the same value if called in the same tick)

**Solution 1**
Just use [`randomUUID()`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID).
This breaks the expected return type of current `payloadId` which is a number

**Solution 2**
_Preserves function signature_
The most simple, performant and (in my opinion) sufficient solution would be the following:

```
export function getPayloadId(): number {
  return crypto.getRandomValues(new Uint16Array(1))[0];
}
```

This would provide a sufficiently random number.

**Solution 3**
_Provide incremental values_
To always return a random value greater than the previous one, we have to introduce some state:

```
let base = 1;

export function getPayloadId(): number {
  return (base++ << 16) + crypto.getRandomValues(new Uint16Array(1))[0];
}
```

This way, `getPayloadId()` will guarantee a random value to be always greater than the previous one, even if the function is called in the same tick.
But this guarantee would only exist within a single runtime, so it will not be preserved between different scripts or session restarts.


**Solution 4**
This is the solution from the current PR. It's quite convoluted, but aims to prevent breaking changes.
```
export function payloadId(entropy = 3): number {
  const generator = entropy > 3 ? uint16Generator : uint8Generator;
  const shift = entropy > 3 ? 1000000 : 10000;
  const date = Date.now() * Math.pow(10, shift);
  const extra = generator.getRandomValue();
  return date + extra;
}
```

This guarantees incremental nature of the function if called within a single runtime and has a quite small intersection window of values between script restarts. Relying on timestamp can't guarantee us anything anyway because they can differ between systems, so this intersection I think is ok.
Also, this solution kinda ignores the `entropy` parameter (not fully, just branching whether or not it's larger than 3), but I don't see much value in preserving it.

---

Tell me what you think. My personal vote is for **Solution 2**, but I understand that it might be undesired to get rid of the incremental nature of the function, even if it worked improperly.