### PR TITLE
fix(deps): ensure no transitive deps on `events` package

### DIFF
--- a/jsonrpc/http-connection/package.json
+++ b/jsonrpc/http-connection/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.6",
     "@walletconnect/safe-json": "^1.0.1",
-    "cross-fetch": "^3.1.4"
+    "cross-fetch": "^3.1.4",
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",

--- a/jsonrpc/provider/package.json
+++ b/jsonrpc/provider/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@walletconnect/jsonrpc-utils": "^1.0.8",
-    "@walletconnect/safe-json": "^1.0.2"
+    "@walletconnect/safe-json": "^1.0.2",
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.1",
@@ -64,11 +65,11 @@
     "@types/node": "^14.14.7",
     "@walletconnect/jsonrpc-http-connection": "^1.0.4",
     "@walletconnect/jsonrpc-ws-connection": "^1.0.10",
-    "@walletconnect/relay-auth": "^1.0.3",
-    "@walletconnect/utils": "^2.1.3",
     "@walletconnect/relay-api": "^1.0.9",
+    "@walletconnect/relay-auth": "^1.0.3",
     "@walletconnect/safe-json": "^1.0.2",
     "@walletconnect/time": "^1.0.2",
+    "@walletconnect/utils": "^2.1.3",
     "@walletconnect/window-getters": "^1.0.1",
     "@walletconnect/window-metadata": "^1.0.1",
     "chai": "^4.2.0",

--- a/jsonrpc/types/package.json
+++ b/jsonrpc/types/package.json
@@ -45,6 +45,7 @@
     "format": "prettier --config ../../.prettierrc --write {src,test}/**/*.ts"
   },
   "dependencies": {
+    "events": "^3.3.0",
     "keyvaluestorage-interface": "^1.0.0"
   },
   "devDependencies": {

--- a/misc/heartbeat/package.json
+++ b/misc/heartbeat/package.json
@@ -45,7 +45,8 @@
   },
   "dependencies": {
     "@walletconnect/events": "^1.0.1",
-    "@walletconnect/time": "^1.0.2"
+    "@walletconnect/time": "^1.0.2",
+    "events": "^3.3.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,8 @@
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
-        "cross-fetch": "^3.1.4"
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.12.1",
@@ -180,7 +181,8 @@
       "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
-        "@walletconnect/safe-json": "^1.0.2"
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.12.1",
@@ -218,6 +220,7 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
+        "events": "^3.3.0",
         "keyvaluestorage-interface": "^1.0.0"
       },
       "devDependencies": {
@@ -443,7 +446,8 @@
       "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
-        "@walletconnect/time": "^1.0.2"
+        "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0"
       },
       "devDependencies": {
         "@types/jest": "^26.0.15",
@@ -29952,6 +29956,7 @@
         "@types/node": "^14.14.7",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0",
         "webpack": "^4.41.6",
         "webpack-cli": "^3.3.11"
       }
@@ -30380,6 +30385,7 @@
         "chai-as-promised": "^7.1.1",
         "core-js": "^3.6.5",
         "cross-fetch": "^3.1.4",
+        "events": "^3.3.0",
         "mocha": "^8.1.3",
         "npm-run-all": "^4.1.5",
         "webpack": "^4.41.6",
@@ -30414,6 +30420,7 @@
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "core-js": "^3.6.5",
+        "events": "^3.3.0",
         "mocha": "^8.1.3",
         "npm-run-all": "^4.1.5",
         "webpack": "^4.41.6",
@@ -30436,6 +30443,7 @@
         "@types/node": "^14.14.7",
         "chai": "^4.2.0",
         "core-js": "^3.6.5",
+        "events": "^3.3.0",
         "keyvaluestorage-interface": "^1.0.0",
         "mocha": "^8.1.3",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
## Context

- Relates to https://github.com/WalletConnect/walletconnect-monorepo/issues/4064
- Ensure that utils packages cannot transitively/implicitly resolve `events` package