### PR TITLE
chore: prep patch releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
           - misc/keyvaluestorage
           - misc/time
           - misc/heartbeat
-          - misc/history
           - misc/environment
           - misc/cacao
           - misc/identity-keys

--- a/jsonrpc/http-connection/package.json
+++ b/jsonrpc/http-connection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/jsonrpc-http-connection",
   "description": "HTTP Connection for JSON-RPC",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "homepage": "https://github.com/WalletConnect/walletconnect-utils/",

--- a/jsonrpc/provider/package.json
+++ b/jsonrpc/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/jsonrpc-provider",
   "description": "Provider for JSON-RPC",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "homepage": "https://github.com/WalletConnect/walletconnect-utils/",

--- a/jsonrpc/types/package.json
+++ b/jsonrpc/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/jsonrpc-types",
   "description": "Typings for JSON-RPC",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "homepage": "https://github.com/WalletConnect/walletconnect-utils/",

--- a/misc/heartbeat/package.json
+++ b/misc/heartbeat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/heartbeat",
   "description": "HeartBeat",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "keywords": [

--- a/misc/history/package.json
+++ b/misc/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@walletconnect/history",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Utilities for communicating with history server",
   "keywords": [
     "history",
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@walletconnect/core": "^2.10.1",
     "@walletconnect/events": "^1.0.1",
-    "@walletconnect/heartbeat": "1.2.1",
     "@walletconnect/jsonrpc-utils": "^1.0.7",
     "@walletconnect/jsonrpc-types": "^1.0.3",
     "@walletconnect/jsonrpc-provider": "^1.0.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,7 @@
     },
     "jsonrpc/http-connection": {
       "name": "@walletconnect/jsonrpc-http-connection",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
@@ -177,7 +177,7 @@
     },
     "jsonrpc/provider": {
       "name": "@walletconnect/jsonrpc-provider",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
@@ -217,7 +217,7 @@
     },
     "jsonrpc/types": {
       "name": "@walletconnect/jsonrpc-types",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",
@@ -442,7 +442,7 @@
     },
     "misc/heartbeat": {
       "name": "@walletconnect/heartbeat",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
@@ -483,6 +483,17 @@
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "lokijs": "^1.5.12"
+      }
+    },
+    "misc/history/node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+      "dev": true,
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "tslib": "1.14.1"
       }
     },
     "misc/identity-keys": {
@@ -29984,6 +29995,19 @@
         "@walletconnect/window-metadata": "^1.0.1",
         "isomorphic-unfetch": "^3.1.0",
         "lokijs": "^1.5.12"
+      },
+      "dependencies": {
+        "@walletconnect/heartbeat": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+          "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+          "dev": true,
+          "requires": {
+            "@walletconnect/events": "^1.0.1",
+            "@walletconnect/time": "^1.0.2",
+            "tslib": "1.14.1"
+          }
+        }
       }
     },
     "@walletconnect/identity-keys": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -458,7 +458,7 @@
     },
     "misc/history": {
       "name": "@walletconnect/history",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/hash": "^5.7.0",
@@ -469,7 +469,6 @@
       "devDependencies": {
         "@walletconnect/core": "^2.10.1",
         "@walletconnect/events": "^1.0.1",
-        "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
@@ -485,20 +484,9 @@
         "lokijs": "^1.5.12"
       }
     },
-    "misc/history/node_modules/@walletconnect/heartbeat": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
-      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
-      "dev": true,
-      "dependencies": {
-        "@walletconnect/events": "^1.0.1",
-        "@walletconnect/time": "^1.0.2",
-        "tslib": "1.14.1"
-      }
-    },
     "misc/identity-keys": {
       "name": "@walletconnect/identity-keys",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/hash": "^5.7.0",
@@ -29979,7 +29967,6 @@
         "@ethersproject/transactions": "^5.7.0",
         "@walletconnect/core": "^2.10.1",
         "@walletconnect/events": "^1.0.1",
-        "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
@@ -29995,19 +29982,6 @@
         "@walletconnect/window-metadata": "^1.0.1",
         "isomorphic-unfetch": "^3.1.0",
         "lokijs": "^1.5.12"
-      },
-      "dependencies": {
-        "@walletconnect/heartbeat": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
-          "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
-          "dev": true,
-          "requires": {
-            "@walletconnect/events": "^1.0.1",
-            "@walletconnect/time": "^1.0.2",
-            "tslib": "1.14.1"
-          }
-        }
       }
     },
     "@walletconnect/identity-keys": {


### PR DESCRIPTION
Prep patch releases for 
-   `@walletconnect/heartbeat`
-   `@walletconnect/jsonrpc-types`
-   `@walletconnect/jsonrpc-provider`
-   `@walletconnect/jsonrpc-http-connection`

and removed `misc/history` from ci due to deprecation