### PR TITLE
fix: Cast WS Connection Origin to undefined

### DIFF
--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -117,7 +117,7 @@ export class WsConnection implements IJsonRpcConnection {
     this.registering = true;
 
     return new Promise((resolve, reject) => {
-      const origin = new URLSearchParams(url).get("origin");
+      const { origin } = new URL(url);
       const opts = isReactNative()
         ? { headers: { origin } }
         : { rejectUnauthorized: !isLocalhostUrl(url) };

--- a/jsonrpc/ws-connection/src/ws.ts
+++ b/jsonrpc/ws-connection/src/ws.ts
@@ -117,9 +117,9 @@ export class WsConnection implements IJsonRpcConnection {
     this.registering = true;
 
     return new Promise((resolve, reject) => {
-      const { origin } = new URL(url);
+      const origin = new URLSearchParams(url).get("origin");
       const opts = isReactNative()
-        ? { headers: { origin } }
+        ? { headers: { origin: origin || undefined } }
         : { rejectUnauthorized: !isLocalhostUrl(url) };
       const socket: WebSocket = new WS(url, [], opts);
       if (hasBuiltInWebSocket()) {


### PR DESCRIPTION
## Fix: Cast WS Connection Origin to undefined

URLSearchParams.get method returns null for params that are not defined, this results in the origin variable to be null, which leads to **a crash in the React Native app** when using sign client with the following error:
```
NSInvalidArgumentException: -[NSNull length]: unrecognized selector sent to instance 0x7ff84002f610
```

The crash only occured on only iOS devices with only specific builds, but still, this causes a crash.

This change ensures that the origin is undefined if not provided and prevents the app from crashing due to the null value.