### PR TITLE
chore(config): ensure root lockfile is updated post-renovate update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     ":semanticCommitScope(deps)"
   ],
   "updateInternalDeps": true,
+  "postUpdateOptions": ["npmDedupe"],
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
## Context

- Renovatebot PRs seem to have started failing on CI due to the root lockfile not being updated after internal `package.json` updates: https://github.com/WalletConnect/walletconnect-utils/actions/runs/9892262113/job/27324513410?pr=74#step:5:9
- Add `postUpdateOptions` which should ensure `npm install` is always run post deps update: https://docs.renovatebot.com/configuration-options/#postupdateoptions

### How has this been tested

- Reproduced the issue with a renovate branch locally and fixed via `npm install` in root dir