### PR TITLE
chore: releases utils

### DIFF
--- a/crypto/crypto/package.json
+++ b/crypto/crypto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/crypto",
   "description": "Isomorphic Cryptography Library for AES, HMAC and SHA2",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "keywords": [

--- a/crypto/ecies-25519/package.json
+++ b/crypto/ecies-25519/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/ecies-25519",
   "description": "Isomorphic Cryptography Library for X25519 ECIES",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "keywords": [

--- a/crypto/randombytes/package.json
+++ b/crypto/randombytes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/randombytes",
   "description": "Isomorphic Library for Random Bytes",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "keywords": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
     },
     "crypto/crypto": {
       "name": "@walletconnect/crypto",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "1.2.0",
@@ -94,7 +94,7 @@
     },
     "crypto/ecies-25519": {
       "name": "@walletconnect/ecies-25519",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.8.0",
@@ -118,7 +118,7 @@
     },
     "crypto/randombytes": {
       "name": "@walletconnect/randombytes",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.7.0",
@@ -23210,7 +23210,7 @@
     },
     "relay/relay-auth": {
       "name": "@walletconnect/relay-auth",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.8.0",

--- a/relay/relay-auth/package.json
+++ b/relay/relay-auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/relay-auth",
   "description": "Relay Client Authentication",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
PR releasing utils
- @walletconnect/crypto@1.1.0
- @walletconnect/ecies-25519@1.1.0
- @walletconnect/randombytes@1.1.0
- @walletconnect/relay-auth@1.1.0

canaries deployments listed in https://github.com/WalletConnect/walletconnect-utils/pull/216