### PR TITLE
feat(ci): add workflow for publishing single canary packages

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,77 @@
+name: Publish Single Package to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to release from"
+        required: true
+        default: "master"
+      packageName:
+        description: "Name of the package to publish (e.g., @walletconnect/utils)"
+        required: true
+      packageDir:
+        description: "Relative path to the package directory (e.g., misc/utils)"
+        required: true
+      version:
+        description: "Specific version to publish (e.g., 1.2.3)"
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # The permissions block is removed as no step needs write access to the repository.
+
+    steps:
+      - name: Checkout code 🛎️
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          # Fetch all history so npm version can determine versions correctly
+          fetch-depth: 0
+
+      - name: Setup Node ⚙️
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+          # Cache npm dependencies based on the lock file
+          cache: "npm"
+
+      - name: Install dependencies 🔧
+        run: npm ci
+
+      # --- Validate Version Format ---
+      # Ensure the provided version string includes '-canary-' as this workflow
+      # is intended specifically for canary releases.
+      - name: Validate canary version format 🔍
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ ! "$VERSION" =~ -canary- ]]; then
+            echo "❌ Invalid version format for canary: '$VERSION'. It must include '-canary-'."
+            exit 1
+          fi
+          echo "✅ Version format '$VERSION' is valid for canary."
+
+      # --- Versioning Step ---
+      # Use npm version to update the package.json in the specific package directory
+      - name: Set package version 🔢
+        run: |
+          echo "Setting version for package in directory: ${{ github.event.inputs.packageDir }}"
+          cd ${{ github.event.inputs.packageDir }}
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version --allow-same-version
+        # --allow-same-version prevents errors if the version is accidentally the same as current
+
+      # --- Build Step ---
+      # Build the target package AND any workspace packages it depends on.
+      - name: Build package and dependencies 🏗️
+        run: npx turbo build --filter=${{ github.event.inputs.packageName }}...
+
+      # --- Publish Step ---
+      - name: Publish to NPM 🚀
+        run: |
+          echo "Publishing package from directory: ${{ github.event.inputs.packageDir }}"
+          cd ${{ github.event.inputs.packageDir }}
+          npm publish --access public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-pkg-canary.yml
+++ b/.github/workflows/publish-pkg-canary.yml
@@ -1,4 +1,4 @@
-name: Publish Single Package to NPM
+name: Publish Single Package Canary to NPM
 
 on:
   workflow_dispatch:
@@ -70,8 +70,8 @@ jobs:
       # --- Publish Step ---
       - name: Publish to NPM 🚀
         run: |
-          echo "Publishing package from directory: ${{ github.event.inputs.packageDir }}"
+          echo "Publishing package from directory: ${{ github.event.inputs.packageDir }} with canary tag"
           cd ${{ github.event.inputs.packageDir }}
-          npm publish --access public
+          npm publish --access public --tag canary
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Description:**

This PR introduces a new GitHub Actions workflow (`.github/workflows/publish-package.yml`) to enable the manual publishing of individual packages as canary versions to npm. This provides a mechanism to release test versions of specific packages without needing a full `changeset`-based release across the monorepo.

**Changes:**

*   **New Workflow (`publish-package.yml`):**
    *   Triggered manually via `workflow_dispatch`.
    *   Accepts inputs for `branch`, `packageName` (npm name), `packageDir` (relative path), and `version`.
    *   Checks out the specified branch.
    *   Sets up Node.js v20 and installs dependencies using `npm ci`.
    *   **Validates** that the provided `version` input string contains `-canary-`.
    *   Uses `npm version` within the target package's directory to update its `package.json` (does *not* commit this change back to the repo).
    *   Builds the target package and its workspace dependencies using `npx turbo build --filter={packageName}...`.
    *   Publishes the built package to npm using `npm publish` and the `NPM_TOKEN` secret.

**How to Use:**

1.  Navigate to the "Actions" tab of the repository.
2.  Find the "Publish Single Package to NPM" workflow in the list.
3.  Click "Run workflow".
4.  Provide the following inputs:
    *   `branch`: The branch containing the code to release (e.g., `master`).
    *   `packageName`: The exact npm package name (e.g., `@walletconnect/heartbeat`).
    *   `packageDir`: The relative path to the package directory from the repo root (e.g., `misc/heartbeat`).
    *   `version`: The full version string, which **must** include `-canary-` (e.g., `1.2.3-canary.1`).
5.  Click "Run workflow" to start the publishing process.

**Context:**

This workflow addresses the need for targeted canary releases for individual packages, decoupled from the standard release process managed by `changeset`. It leverages `turbo` for efficient building and standard `npm` commands for versioning and publishing within the action's context.