### PR TITLE
feat(ci): refine CI workflow triggers for specific paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,20 @@
-on: push
+on:
+  push:
+    paths:
+      - "misc/**"
+      - "crypto/**"
+      - "jsonrpc/**"
+      - "browser/**"
+      - "relay/**"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    paths:
+      - "misc/**"
+      - "crypto/**"
+      - "jsonrpc/**"
+      - "browser/**"
+      - "relay/**"
+      - ".github/workflows/ci.yml"
 
 name: CI Checks
 


### PR DESCRIPTION
Updated the GitHub Actions CI workflow to trigger on pushes and pull requests for specific directories: `misc`, `crypto`, `jsonrpc`, `browser`, `relay`, and the workflow file itself. This enhancement improves the efficiency of CI checks by limiting them to relevant changes.