### PR TITLE
fix(ci): update npm authentication method in canary publishing workflow

### DIFF
--- a/.github/workflows/publish-pkg-canary.yml
+++ b/.github/workflows/publish-pkg-canary.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Install dependencies 🔧
         run: npm ci
 
-      - name: Setup npm auth token 🔑
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > $HOME/.npmrc
-
       # --- Validate Version Format ---
       # Ensure the provided version string includes '-canary-' as this workflow
       # is intended specifically for canary releases.
@@ -77,4 +74,4 @@ jobs:
           cd ${{ github.event.inputs.packageDir }}
           npm publish --access public --tag canary
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removed the explicit npm authentication step and replaced the environment variable from `NPM_TOKEN` to `NODE_AUTH_TOKEN`