### PR TITLE
chore(workflows): add Changesets release workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -1,0 +1,60 @@
+name: Changesets
+on:
+  push:
+    branches: [master]
+
+concurrency:
+  # Group concurrency by workflow and ref
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changesets:
+    name: Changesets Release
+    # Ensures the workflow has permissions to create PRs, write content (commits, tags, releases), and potentially use OIDC for auth
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history so Changesets can generate changelogs accurately
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          cache: "npm"
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Packages
+        run: npm run build
+
+      - name: Setup npm Authentication
+        # Sets up .npmrc for publishing using the provided NPM_TOKEN secret
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > $HOME/.npmrc
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: npm run npm-publish
+          version: npm run changeset:version
+          title: "chore: version packages"
+          commit: "chore: version packages"
+          # Create GitHub releases only when merging to the master branch
+          createGithubReleases: ${{ github.ref == 'refs/heads/master' }}
+        env:
+          # GITHUB_TOKEN is required by changesets/action to create PRs, releases, etc.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NPM_TOKEN is required for the 'npm run npm-publish' step
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

This PR introduces a new GitHub Actions workflow (`.github/workflows/changesets.yml`) to automate the package release process using [Changesets](https://github.com/changesets/changesets).

## Key Features

*   **Automated Versioning & Changelogs:** Leverages Changesets to automatically bump package versions and generate changelogs based on changeset files committed by developers.
*   **Trigger:** The workflow runs automatically on every push to the `master` branch.
*   **Process:**
    *   Checks out the code.
    *   Sets up Node.js and installs dependencies using `npm ci`.
    *   Builds the packages using `npm run build` (`turbo build`).
    *   Authenticates with npm using the `NPM_TOKEN` secret.
    *   Runs `changesets/action@v1`:
        *   If changeset files are present, it runs `npm run changeset:version` to consume them, update `package.json` versions, and update changelog files. It then commits these changes and creates a Pull Request titled "chore: version packages".
        *   If the push is directly to `master` (e.g., after the versioning PR is merged) and changeset files were consumed in the versioning step, it runs `npm run npm-publish` to publish the updated packages to npm and creates a corresponding GitHub Release.
*   **Concurrency Control:** Ensures only one workflow run executes per branch at a time, canceling older runs on new pushes.

## Important Notes

*   **`NPM_TOKEN` Secret:** This workflow requires an `NPM_TOKEN` secret to be configured in the repository settings (`Settings > Secrets and variables > Actions`). This token must have publish permissions for the relevant packages on npm.
*   **Branch Configuration:** The workflow is currently configured to trigger on the `master` branch. This can be adjusted in the `.github/workflows/changesets.yml` file if needed.

This automation aims to streamline the release process, ensure consistent versioning and changelogs, and reduce manual effort.