### PR TITLE
fix: update WebSocket relay URL to production endpoint

### DIFF
--- a/jsonrpc/provider/test/index.test.ts
+++ b/jsonrpc/provider/test/index.test.ts
@@ -56,7 +56,7 @@ const TEST_URL = {
     bad: `http://${TEST_RANDOM_HOST}`,
   },
   ws: {
-    good: `wss://staging.relay.walletconnect.com`,
+    good: `wss://relay.walletconnect.com`,
     bad: `ws://${TEST_RANDOM_HOST}`,
   },
 };

--- a/jsonrpc/ws-connection/test/shared/values.ts
+++ b/jsonrpc/ws-connection/test/shared/values.ts
@@ -1,1 +1,1 @@
-export const RELAY_URL = "wss://staging.relay.walletconnect.com";
+export const RELAY_URL = "wss://relay.walletconnect.com";


### PR DESCRIPTION
## Context
* The calls to deprecated staging.relay.walletconnect.com were no longer resolving.
* Replaced the staging WebSocket relay URL with the production URL in tests.