### PR TITLE
chore: remove redundant package name from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "walletconnect-utils",
   "description": "Monorepo for Javascript Utilities for WalletConnect",
   "private": true,
   "author": "WalletConnect, Inc. <walletconnect.com>",


### PR DESCRIPTION
Removing "name" prop as unnecessary and inaccurate since this is a private monorepo workspace root package.json