### PR TITLE
fix: pino esm

### DIFF
--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/logger",
   "description": "Logger Utils",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "homepage": "https://github.com/WalletConnect/walletconnect-utils/",

--- a/misc/logger/src/index.ts
+++ b/misc/logger/src/index.ts
@@ -1,5 +1,5 @@
 import * as Pino from "pino";
-const defaultPino = Pino.default ?? Pino;
+const defaultPino = Pino.default ?? Pino.pino;
 export * from "./constants";
 export * from "./utils";
 export type { Logger } from "pino";

--- a/misc/logger/src/index.ts
+++ b/misc/logger/src/index.ts
@@ -1,6 +1,6 @@
-/* eslint-disable-next-line import/no-named-default */
-import { default as pino } from "pino";
+import * as Pino from "pino";
+const defaultPino = Pino.default ?? Pino;
 export * from "./constants";
 export * from "./utils";
 export type { Logger } from "pino";
-export { pino };
+export { defaultPino as pino };

--- a/misc/logger/src/index.ts
+++ b/misc/logger/src/index.ts
@@ -1,5 +1,5 @@
 import * as Pino from "pino";
-const defaultPino = Pino.default ?? Pino.pino;
+const defaultPino = Pino.default ?? Pino;
 export * from "./constants";
 export * from "./utils";
 export type { Logger } from "pino";

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,7 +350,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "isomorphic-unfetch": "^3.1.0"
       }
@@ -457,7 +457,7 @@
       "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "@walletconnect/utils": "^2.10.1",
         "isomorphic-unfetch": "^3.1.0"
@@ -485,7 +485,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",
@@ -1389,7 +1389,7 @@
     },
     "misc/logger": {
       "name": "@walletconnect/logger",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
@@ -28395,7 +28395,7 @@
     "@walletconnect/cacao": {
       "version": "file:misc/cacao",
       "requires": {
-        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "isomorphic-unfetch": "^3.1.0"
       }
@@ -28564,7 +28564,7 @@
     "@walletconnect/history": {
       "version": "file:misc/history",
       "requires": {
-        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "@walletconnect/core": "^2.10.1",
         "@walletconnect/events": "^1.0.1",
@@ -28588,7 +28588,7 @@
     "@walletconnect/identity-keys": {
       "version": "file:misc/identity-keys",
       "requires": {
-        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/transactions": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
         "@noble/ed25519": "^1.7.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update logger to import and re-export pino compatibly with ESM/CJS and bump package to 2.1.3.
> 
> - **Logger (`misc/logger`)**:
>   - **ESM/CJS interop**: Change `src/index.ts` to `import * as Pino` and export `defaultPino as pino` (fallback to `Pino.default ?? Pino`).
>   - **Version**: Bump `package.json` from `2.1.2` to `2.1.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c98e920e25294751ea09508145a7853ba986f430. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->