### PR TITLE
fix: avoid exposing browser-only ESM build via module  #237

### DIFF
--- a/misc/keyvaluestorage/package.json
+++ b/misc/keyvaluestorage/package.json
@@ -17,7 +17,6 @@
     "dist"
   ],
   "main": "dist/index.cjs.js",
-  "module": "dist/index.es.js",
   "browser": "dist/index.es.js",
   "unpkg": "dist/index.umd.js",
   "types": "dist/types/index.d.ts",


### PR DESCRIPTION
`module` was pointing to a browser-only ESM build that references `indexedDB`,
which causes Node.js to throw `ReferenceError: indexedDB is not defined` in
non-browser environments.

This change removes the `module` entry to ensure:
- Node.js only resolves Node-safe entry points
- browser bundlers continue to use the browser build

Note: `module` is valid for Node.js when it points to a Node-safe ESM build.
In this package it currently resolves to a browser-only output, so removing
the entry avoids the runtime crash until a Node-compatible ESM build exists.

Build verification is covered by CI.
