### PR TITLE
fix(logger): pass loggerOverride string as log level to chunk logger

### DIFF
--- a/misc/logger/package.json
+++ b/misc/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/logger",
   "description": "Logger Utils",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "license": "MIT",
   "homepage": "https://github.com/WalletConnect/walletconnect-utils/",

--- a/misc/logger/src/utils.ts
+++ b/misc/logger/src/utils.ts
@@ -76,10 +76,15 @@ export function generateServerLogger(params: { maxSizeInBytes?: number; opts?: L
   chunkLoggerController: ServerChunkLogger;
 } {
   const serverLogger = new ServerChunkLogger(params.opts?.level, params.maxSizeInBytes);
+  // Use both destination stream (for Node.js pino) and browser.write (for bundled pino-browser)
   const logger = pino(
     {
       ...params.opts,
       level: "trace",
+      browser: {
+        ...params.opts?.browser,
+        write: (obj) => serverLogger.write(obj),
+      },
     },
     serverLogger,
   );
@@ -102,9 +107,15 @@ export function generatePlatformLogger(params: {
     };
   }
 
+  // When loggerOverride is a string, use it as the log level
+  const opts: LoggerOptions = {
+    ...params.opts,
+    level: typeof params.loggerOverride === "string" ? params.loggerOverride : params.opts?.level,
+  };
+
   if (typeof window !== "undefined") {
-    return generateClientLogger(params);
+    return generateClientLogger({ ...params, opts });
   } else {
-    return generateServerLogger(params);
+    return generateServerLogger({ ...params, opts });
   }
 }

--- a/misc/logger/test/index.test.ts
+++ b/misc/logger/test/index.test.ts
@@ -9,6 +9,7 @@ import {
   getDefaultLoggerOptions,
   generateChildLogger,
   generateServerLogger,
+  generatePlatformLogger,
 } from "../src";
 
 describe("Logger", () => {
@@ -250,6 +251,78 @@ describe("Logger", () => {
         chai.expect(logArray.filter((log) => log.includes(nString)).length).eq(1);
         chai.expect(logArray.filter((log) => log.includes(oString)).length).eq(1);
         chai.expect(logArray.filter((log) => log.includes(pString)).length).eq(1);
+      });
+    });
+
+    describe("Platform Logger", () => {
+      let consoleTrace: sinon.SinonStub;
+      let consoleDebug: sinon.SinonStub;
+      let consoleLog: sinon.SinonStub;
+      let consoleWarn: sinon.SinonStub;
+      let consoleError: sinon.SinonStub;
+
+      beforeEach(() => {
+        consoleTrace = sinon.stub(console, "trace");
+        consoleDebug = sinon.stub(console, "debug");
+        consoleLog = sinon.stub(console, "log");
+        consoleWarn = sinon.stub(console, "warn");
+        consoleError = sinon.stub(console, "error");
+      });
+
+      afterEach(() => {
+        consoleTrace.restore();
+        consoleDebug.restore();
+        consoleLog.restore();
+        consoleWarn.restore();
+        consoleError.restore();
+      });
+
+      it("Respects loggerOverride string as log level for console output", () => {
+        // Use "warn" level (NOT "error") to avoid coincidentally matching the default
+        // The default level in BaseChunkLogger is "error", so using "error" here
+        // would pass even if loggerOverride is not properly passed through
+        const { logger, chunkLoggerController } = generatePlatformLogger({
+          loggerOverride: "warn",
+        });
+
+        logger.trace("trace message");
+        logger.debug("debug message");
+        logger.info("info message");
+        logger.warn("warn message");
+        logger.error("error message");
+
+        const logArray = chunkLoggerController!.getLogArray();
+
+        // All logs should be stored in memory
+        chai.expect(logArray.length).eq(5);
+
+        // Only warn and error should be forwarded to console
+        chai.expect(consoleTrace.called).eq(false);
+        chai.expect(consoleDebug.called).eq(false);
+        chai.expect(consoleLog.called).eq(false);
+        chai.expect(consoleWarn.called).eq(true);
+        chai.expect(consoleError.called).eq(true);
+      });
+
+      it("Stores all logs in memory regardless of level", () => {
+        const { logger, chunkLoggerController } = generatePlatformLogger({
+          loggerOverride: "warn",
+        });
+
+        logger.trace("trace");
+        logger.debug("debug");
+        logger.info("info");
+        logger.warn("warn");
+        logger.error("error");
+
+        const logArray = chunkLoggerController!.getLogArray();
+
+        // All 5 logs should be stored
+        chai.expect(logArray.filter((log) => log.includes("trace")).length).eq(1);
+        chai.expect(logArray.filter((log) => log.includes("debug")).length).eq(1);
+        chai.expect(logArray.filter((log) => log.includes("info")).length).eq(1);
+        chai.expect(logArray.filter((log) => log.includes("warn")).length).eq(1);
+        chai.expect(logArray.filter((log) => log.includes("error")).length).eq(1);
       });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9064,7 +9064,7 @@
     },
     "misc/logger": {
       "name": "@walletconnect/logger",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",


### PR DESCRIPTION
## Summary

- **Fixed** `generatePlatformLogger` not passing the `loggerOverride` string (e.g., `"error"`) to the chunk logger, causing all logs to be forwarded to console regardless of configured level
- **Fixed** `generateServerLogger` not working with bundled `pino-browser` by adding `browser.write` option alongside the destination stream
- **Added** tests to verify `loggerOverride` string is properly respected for console filtering
- **Bumped** version to 3.0.2

## Problem 1: loggerOverride Not Passed Through

When users set `logger: "error"` in WalletConnect SDK options, trace-level logs were still being output to console. The `loggerOverride` string was stored in `params.loggerOverride` but never passed through to `generateClientLogger`/`generateServerLogger`, which expected the level in `params.opts?.level`.

```mermaid
flowchart LR
    A[User sets logger: 'error'] --> B[generatePlatformLogger]
    B --> C{loggerOverride is string?}
    C -->|Yes - BEFORE| D[❌ Level ignored]
    C -->|Yes - AFTER| E[✅ Level passed via opts]
    E --> F[ChunkLogger filters console output]
```

## Problem 2: pino-browser Ignoring Destination Stream

The `generateServerLogger` function passed `ServerChunkLogger` as the second argument (destination stream) to pino. However, the bundled version uses `pino-browser`, which **ignores** the destination argument and expects logging to be configured via `browser.write` option instead.

```typescript
// Before (broken in bundled version):
const logger = pino(
  { ...params.opts, level: "trace" },
  serverLogger,  // pino-browser ignores this!
);

// After (works in both Node.js and bundled):
const logger = pino(
  {
    ...params.opts,
    level: "trace",
    browser: {
      write: (obj) => serverLogger.write(obj),  // For pino-browser
    },
  },
  serverLogger,  // For Node.js pino (tests)
);
```

## Solution

1. When `loggerOverride` is a string in `generatePlatformLogger`, create a new `opts` object with the level set and pass it to the client/server logger generators
2. Add `browser.write` option to `generateServerLogger` so logs go through our filter in the bundled version

This ensures all logs go through `BaseChunkLogger.appendToLogs()`, which properly filters based on the configured level before calling `forwardToConsole()`.

## Test plan

- [x] Run `npm test` in `misc/logger` - all 18 tests pass
- [x] New tests verify:
  - `loggerOverride: "warn"` only forwards warn/error to console
  - All logs (trace, debug, info, warn, error) are still stored in memory