### PR TITLE
fix(types): make getEntries return unknown instead of generic T

### DIFF
--- a/misc/keyvaluestorage/src/browser/index.ts
+++ b/misc/keyvaluestorage/src/browser/index.ts
@@ -29,7 +29,7 @@ export class KeyValueStorage implements IKeyValueStorage {
     return this.storage.getKeys();
   }
 
-  public async getEntries<T = any>(): Promise<[string, T][]> {
+  public async getEntries(): Promise<[string, unknown][]> {
     await this.initialize();
     return this.storage.getEntries();
   }

--- a/misc/keyvaluestorage/src/browser/lib/indexedDb.ts
+++ b/misc/keyvaluestorage/src/browser/lib/indexedDb.ts
@@ -19,9 +19,9 @@ export class IndexedDb implements IKeyValueStorage {
     return this.indexedDb.getKeys();
   }
 
-  public async getEntries<T = any>(): Promise<[string, T][]> {
+  public async getEntries(): Promise<[string, unknown][]> {
     const entries = await this.indexedDb.getItems(await this.indexedDb.getKeys());
-    return entries.map((item: any) => [item.key, item.value] as [string, T]);
+    return entries.map((item: any) => [item.key, item.value]);
   }
 
   public async getItem<T = any>(key: string): Promise<T | undefined> {

--- a/misc/keyvaluestorage/src/browser/lib/localStore.ts
+++ b/misc/keyvaluestorage/src/browser/lib/localStore.ts
@@ -10,7 +10,7 @@ export class LocalStore implements IKeyValueStorage {
     return Object.keys(this.localStorage);
   }
 
-  public async getEntries<T = any>(): Promise<[string, T][]> {
+  public async getEntries(): Promise<[string, unknown][]> {
     return Object.entries(this.localStorage).map(parseEntry);
   }
 

--- a/misc/keyvaluestorage/src/node-js/index.ts
+++ b/misc/keyvaluestorage/src/node-js/index.ts
@@ -25,7 +25,7 @@ export class KeyValueStorage implements IKeyValueStorage {
     return this.database.getKeys();
   }
 
-  public async getEntries<T = any>(): Promise<[string, T][]> {
+  public async getEntries(): Promise<[string, unknown][]> {
     await this.initialize();
     return this.database.getEntries();
   }

--- a/misc/keyvaluestorage/src/node-js/lib/db.ts
+++ b/misc/keyvaluestorage/src/node-js/lib/db.ts
@@ -73,9 +73,9 @@ export default class Db {
     return this.database.getKeys();
   }
 
-  public async getEntries<T = any>(): Promise<[string, T][]> {
+  public async getEntries(): Promise<[string, unknown][]> {
     const entries = await this.database.getItems(await this.database.getKeys());
-    return entries.map((item: any) => [item.key, item.value] as [string, T]);
+    return entries.map((item: any) => [item.key, item.value]);
   }
 
   private async onWriteAction(params: {

--- a/misc/keyvaluestorage/src/react-native/index.ts
+++ b/misc/keyvaluestorage/src/react-native/index.ts
@@ -12,7 +12,7 @@ export class KeyValueStorage implements IKeyValueStorage {
     return this.asyncStorage.getAllKeys() as Promise<string[]>;
   }
 
-  public async getEntries<T = any>(): Promise<[string, T][]> {
+  public async getEntries(): Promise<[string, unknown][]> {
     const keys = await this.getKeys();
     const entries = await this.asyncStorage.multiGet(keys);
     return entries.map(parseEntry);

--- a/misc/keyvaluestorage/src/shared/types.ts
+++ b/misc/keyvaluestorage/src/shared/types.ts
@@ -5,7 +5,7 @@ export interface KeyValueStorageOptions {
 
 export abstract class IKeyValueStorage {
   public abstract getKeys(): Promise<string[]>;
-  public abstract getEntries<T = any>(): Promise<[string, T][]>;
+  public abstract getEntries(): Promise<[string, unknown][]>;
   public abstract getItem<T = any>(key: string): Promise<T | undefined>;
   public abstract setItem<T = any>(key: string, value: T): Promise<void>;
   public abstract removeItem(key: string): Promise<void>;


### PR DESCRIPTION
## Summary

Fixes the incorrect typing of `getEntries()`.

The previous signature exposed a generic `<T>`, which implied that all returned entries share the same type. Since the storage can contain heterogeneous values (sessions, pairings, metadata, etc.), this assumption is not guaranteed and therefore unsound.

## Background

`getEntries<T>()` suggests that consumers can safely expect every stored value to conform to `T`. However, the underlying storage layer is type-agnostic and may return different object shapes depending on what was persisted.

This mismatch between the type contract and runtime behavior can lead to incorrect assumptions or unsafe downstream usage.

## Changes

- Removed the generic parameter from `getEntries`
- Updated return type to:
  `Promise<[string, unknown][]>`
- Removed unsafe casts (`as [string, T]`) in implementations
- No runtime behavior changes

## Scope

This PR strictly corrects the type definition to reflect actual storage behavior.  
No changes were made to persistence logic, session handling, or storage flow.

All existing behavior remains unchanged.