### PR TITLE
fix(relay-auth): reject expired JWTs in verifyJWT

### DIFF
--- a/relay/relay-auth/src/api.ts
+++ b/relay/relay-auth/src/api.ts
@@ -42,5 +42,18 @@ export async function verifyJWT(jwt: string) {
     throw new Error("JWT must use EdDSA algorithm");
   }
   const publicKey = decodeIss(payload.iss);
-  return ed25519.verify(signature, data, publicKey);
+  const validSig = ed25519.verify(signature, data, publicKey);
+  if (!validSig) {
+    return false;
+  }
+  // signJWT always sets exp; reject missing/non-numeric or expired claims so a
+  // captured relay JWT cannot verify forever after TTL.
+  if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) {
+    return false;
+  }
+  const now = fromMiliseconds(Date.now());
+  if (payload.exp <= now) {
+    return false;
+  }
+  return true;
 }

--- a/relay/relay-auth/test/index.test.ts
+++ b/relay/relay-auth/test/index.test.ts
@@ -49,7 +49,7 @@ describe("Relay Auth", () => {
     const data = encodeData({ header, payload });
     chai.expect(data).to.eql(fromString(EXPECTED_DATA, "utf8"));
   });
-  it("sign and verify JWT", async () => {
+  it("sign deterministic JWT and decode payload", async () => {
     const seed = fromString(TEST_SEED, "base16");
     const keyPair = generateKeyPair(seed);
     const sub = TEST_SUBJECT;
@@ -59,14 +59,20 @@ describe("Relay Auth", () => {
     const iat = TEST_IAT;
     const jwt = await signJWT(sub, aud, ttl, keyPair, iat);
     chai.expect(jwt).to.eql(EXPECTED_JWT);
+    // Historical vector is past exp; verifyJWT must fail closed on expiry.
     const verified = await verifyJWT(jwt);
-    chai.expect(verified).to.eql(true);
+    chai.expect(verified).to.eql(false);
     const decoded = didJWT.decodeJWT(jwt);
     chai.expect(decoded).to.eql(EXPECTED_DECODED);
-    // FIXME: currently errors with 'Unknown file extension ".ts"'
-    // const resolver = new Resolver(KeyDIDResolver.getResolver());
-    // const response = await didJWT.verifyJWT(jwt, { resolver });
-    // // eslint-disable-next-line
-    // console.log("response", response);
+  });
+
+  it("rejects expired JWT and accepts fresh JWT", async () => {
+    const seed = fromString(TEST_SEED, "base16");
+    const keyPair = generateKeyPair(seed);
+    const now = Math.floor(Date.now() / 1000);
+    const fresh = await signJWT(TEST_SUBJECT, TEST_AUDIENCE, TEST_TTL, keyPair, now);
+    chai.expect(await verifyJWT(fresh)).to.eql(true);
+    const expired = await signJWT(TEST_SUBJECT, TEST_AUDIENCE, 3600, keyPair, now - 7200);
+    chai.expect(await verifyJWT(expired)).to.eql(false);
   });
 });


### PR DESCRIPTION
## Summary
- `@walletconnect/relay-auth` `signJWT` always sets `exp`, but `verifyJWT` only checked the EdDSA signature.
- A captured relay JWT therefore remained valid forever against `verifyJWT` until the client key rotates.
- After signature verification, require a finite `payload.exp` and reject when `exp <= now`.

Sibling of open cacao #278 (distinct surface).

## Test plan
- [x] `npm run build -- --filter=./relay/relay-auth && npm test --workspace=@walletconnect/relay-auth` → 6/6
- [x] Fresh JWT verifies; expired JWT (ttl elapsed) returns false; historical EXPECTED_JWT fails closed on expiry
- [ ] CI green on this PR

Tooling assist used for prep; commit authored/signed by me (no Cursor co-author trailer).

Made with [Cursor](https://cursor.com)