### PR TITLE
fix(cacao): reject CR/LF in all SIWE single-line fields

### DIFF
--- a/misc/cacao/src/utils.ts
+++ b/misc/cacao/src/utils.ts
@@ -47,6 +47,13 @@ export const formatMessage = (cacao: CacaoPayload, iss: string) => {
       ? `Resources:\n${cacao.resources.map((resource) => `- ${resource}`).join("\n")}`
       : undefined;
 
+  // Per EIP-4361 the statement is a single line. Reject embedded breaks so a
+  // caller-supplied statement cannot forge later fields (URI, Nonce, etc.).
+  // Parity with @walletconnect/utils formatMessage in walletconnect-monorepo.
+  if (statement && /\r|\n/.test(statement)) {
+    throw new Error("Statement must not contain line breaks (`\\r` or `\\n`)");
+  }
+
   const message = [
     header,
     walletAddress,

--- a/misc/cacao/src/utils.ts
+++ b/misc/cacao/src/utils.ts
@@ -47,11 +47,25 @@ export const formatMessage = (cacao: CacaoPayload, iss: string) => {
       ? `Resources:\n${cacao.resources.map((resource) => `- ${resource}`).join("\n")}`
       : undefined;
 
-  // Per EIP-4361 the statement is a single line. Reject embedded breaks so a
-  // caller-supplied statement cannot forge later fields (URI, Nonce, etc.).
+  // Per EIP-4361 single-line fields must not contain line breaks. Reject caller-supplied
+  // domain / aud / version / nonce / iat (and optional exp/nbf/requestId) as well as
+  // statement so embedded `\r`/`\n` cannot forge other fields in the signed message.
   // Parity with @walletconnect/utils formatMessage in walletconnect-monorepo.
-  if (statement && /\r|\n/.test(statement)) {
-    throw new Error("Statement must not contain line breaks (`\\r` or `\\n`)");
+  const singleLineFields: Array<[string, string | undefined]> = [
+    ["Domain", cacao.domain],
+    ["URI", cacao.aud],
+    ["Version", cacao.version],
+    ["Nonce", cacao.nonce],
+    ["Issued At", cacao.iat],
+    ["Expiration Time", cacao.exp],
+    ["Not Before", cacao.nbf],
+    ["Request ID", cacao.requestId],
+    ["Statement", statement],
+  ];
+  for (const [name, value] of singleLineFields) {
+    if (value && /\r|\n/.test(value)) {
+      throw new Error(`${name} must not contain line breaks (\`\\r\` or \`\\n\`)`);
+    }
   }
 
   const message = [

--- a/misc/cacao/test/formatMessage.test.ts
+++ b/misc/cacao/test/formatMessage.test.ts
@@ -1,0 +1,39 @@
+import "mocha";
+import { expect } from "chai";
+import { formatMessage } from "../src/utils";
+import { CacaoPayload } from "../src/types";
+
+const iss = "did:pkh:eip155:1:0x2faf83c542b68f1b4cdc0e770e8cb9f567b08f71";
+
+const base: CacaoPayload = {
+  iss,
+  domain: "example.com",
+  aud: "https://example.com/login",
+  version: "1",
+  nonce: "12345678",
+  iat: "2024-01-01T00:00:00.000Z",
+  statement: "I accept the Terms of Service",
+};
+
+describe("formatMessage", () => {
+  it("formats a normal statement", () => {
+    const message = formatMessage(base, iss);
+    expect(message).to.include("I accept the Terms of Service");
+    expect(message).to.include("URI: https://example.com/login");
+  });
+
+  it("rejects statement with embedded newline (field smuggling)", () => {
+    expect(() =>
+      formatMessage(
+        { ...base, statement: "I accept\nURI: https://evil.com" },
+        iss,
+      ),
+    ).to.throw("Statement must not contain line breaks");
+  });
+
+  it("rejects statement with carriage return", () => {
+    expect(() =>
+      formatMessage({ ...base, statement: "I accept\rURI: https://evil.com" }, iss),
+    ).to.throw("Statement must not contain line breaks");
+  });
+});

--- a/misc/cacao/test/formatMessage.test.ts
+++ b/misc/cacao/test/formatMessage.test.ts
@@ -36,4 +36,22 @@ describe("formatMessage", () => {
       formatMessage({ ...base, statement: "I accept\rURI: https://evil.com" }, iss),
     ).to.throw("Statement must not contain line breaks");
   });
+
+  it("rejects domain with embedded newline (field smuggling)", () => {
+    expect(() =>
+      formatMessage({ ...base, domain: "good.com\nURI: https://evil.com" }, iss),
+    ).to.throw("Domain must not contain line breaks");
+  });
+
+  it("rejects aud with embedded newline", () => {
+    expect(() =>
+      formatMessage({ ...base, aud: "https://example.com/login\nURI: https://evil.com" }, iss),
+    ).to.throw("URI must not contain line breaks");
+  });
+
+  it("rejects nonce with carriage return", () => {
+    expect(() => formatMessage({ ...base, nonce: "1234\r5678" }, iss)).to.throw(
+      "Nonce must not contain line breaks",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
`formatMessage` previously only rejected line breaks in `statement`. Caller-supplied `domain`, `aud`, `version`, `nonce`, `iat` (and optional `exp` / `nbf` / `requestId`) could still embed `\r`/`\n` and forge later EIP-4361 fields (for example a smuggled `URI:` line).

This extends the same single-line reject to those fields. Parity with `@walletconnect/utils` `formatMessage` in walletconnect-monorepo (#7311).

## Test plan
- [x] `formatMessage.test.ts` covers statement, domain, aud, nonce (6/6 with `TEST_PROJECT_ID` stub for suite load)